### PR TITLE
Fix segfault when clearing result yielded to notice_receiver

### DIFF
--- a/ext/pg.h
+++ b/ext/pg.h
@@ -115,6 +115,7 @@ extern VALUE rb_eConnectionBad;
 extern VALUE rb_mPGconstants;
 extern VALUE rb_cPGconn;
 extern VALUE rb_cPGresult;
+extern VALUE rb_cPGnoticeReceiverResult;
 extern VALUE rb_hErrors;
 
 

--- a/ext/pg_result.c
+++ b/ext/pg_result.c
@@ -8,6 +8,7 @@
 
 
 VALUE rb_cPGresult;
+VALUE rb_cPGnoticeReceiverResult;
 
 static void pgresult_gc_free( PGresult * );
 static PGresult* pgresult_get( VALUE );
@@ -117,6 +118,22 @@ VALUE
 pg_result_clear(VALUE self)
 {
 	PQclear(pgresult_get(self));
+	DATA_PTR(self) = NULL;
+	return Qnil;
+}
+
+
+/*
+ * call-seq:
+ *    res.clear() -> nil
+ *
+ * Clears the PG::Result object as the result of the query.  As the underlying
+ * notice receiver result is cleared by libpq automatically, does not clear
+ * the underlying result to avoid a double free.
+ */
+VALUE
+pg_notice_receiver_result_clear(VALUE self)
+{
 	DATA_PTR(self) = NULL;
 	return Qnil;
 }
@@ -873,6 +890,7 @@ void
 init_pg_result()
 {
 	rb_cPGresult = rb_define_class_under( rb_mPG, "Result", rb_cObject );
+	rb_cPGnoticeReceiverResult = rb_define_class_under( rb_mPG, "NoticeReceiverResult", rb_cPGresult );
 	rb_include_module(rb_cPGresult, rb_mEnumerable);
 	rb_include_module(rb_cPGresult, rb_mPGconstants);
 
@@ -884,6 +902,7 @@ init_pg_result()
 	rb_define_method(rb_cPGresult, "error_field", pgresult_error_field, 1);
 	rb_define_alias( rb_cPGresult, "result_error_field", "error_field" );
 	rb_define_method(rb_cPGresult, "clear", pg_result_clear, 0);
+	rb_define_method(rb_cPGnoticeReceiverResult, "clear", pg_notice_receiver_result_clear, 0);
 	rb_define_method(rb_cPGresult, "check", pg_result_check, 0);
 	rb_define_alias (rb_cPGresult, "check_result", "check");
 	rb_define_method(rb_cPGresult, "ntuples", pgresult_ntuples, 0);

--- a/spec/pg/connection_spec.rb
+++ b/spec/pg/connection_spec.rb
@@ -1146,6 +1146,19 @@ describe PG::Connection do
 			conn.finish if conn
 		end
 
+		it "handle clearing result in or after set_notice_receiver", :postgresql_90 do
+			r = nil
+			@conn.set_notice_receiver do |result|
+				r = result
+				result.clear
+			end
+			@conn.exec "do $$ BEGIN RAISE NOTICE 'foo'; END; $$ LANGUAGE plpgsql;"
+			sleep 0.2
+			r.should_not == nil
+			r.clear
+			@conn.set_notice_receiver
+		end
+
 		it "receives properly encoded messages in the notice callbacks", :postgresql_90 do
 			[:receiver, :processor].each do |kind|
 				notices = []


### PR DESCRIPTION
This fixes issue #185 in bitbucket (which I reported). In order
to make a double free impossible, you need to make sure that
clearing the notice receiver result doesn't call PQclear. In
order to make a segfault impossible if accessing the notice
receiver result outside of the notice receiver proc, you need
to use rb_ensure to ensure the data pointer is cleared before
returning from the proc call.

This is the simplest implementation I could think of, using a
result subclass for the notice receiver results, where clear
doesn't call PQclear.