### PR TITLE
Use fixed size arrays in case the compiler doesn't support C99 variable ...

### DIFF
--- a/ext/extconf.rb
+++ b/ext/extconf.rb
@@ -94,6 +94,10 @@ $defs.push( "-DHAVE_ST_NOTIFY_EXTRA" ) if
 have_header 'unistd.h'
 have_header 'ruby/st.h' or have_header 'st.h' or abort "pg currently requires the ruby/st.h header"
 
+checking_for "C99 variable length arrays" do
+	$defs.push( "-DHAVE_VARIABLE_LENGTH_ARRAYS" ) if try_compile('void test_vla(int l){ int vla[l]; }')
+end
+
 create_header()
 create_makefile( "pg_ext" )
 

--- a/ext/pg.h
+++ b/ext/pg.h
@@ -133,6 +133,15 @@
 typedef long suseconds_t;
 #endif
 
+#if defined(HAVE_VARIABLE_LENGTH_ARRAYS)
+	#define PG_VARIABLE_LENGTH_ARRAY(type, name, len, maxlen) type name[(len)];
+#else
+	#define PG_VARIABLE_LENGTH_ARRAY(type, name, len, maxlen) \
+		type name[(maxlen)] = {(len)>(maxlen) ? (rb_raise(rb_eArgError, "Number of " #name " (%d) exceeds allowed maximum of " #maxlen, (len) ), (type)1) : (type)0};
+
+	#define PG_MAX_COLUMNS 4000
+#endif
+
 /* The data behind each PG::Connection object */
 typedef struct {
 	PGconn *pgconn;

--- a/ext/pg_result.c
+++ b/ext/pg_result.c
@@ -863,7 +863,7 @@ pgresult_each_row(VALUE self)
 	num_fields = PQnfields(this->pgresult);
 
 	for ( row = 0; row < num_rows; row++ ) {
-		VALUE row_values[num_fields];
+		PG_VARIABLE_LENGTH_ARRAY(VALUE, row_values, num_fields, PG_MAX_COLUMNS)
 
 		/* populate the row */
 		for ( field = 0; field < num_fields; field++ ) {
@@ -892,7 +892,7 @@ pgresult_values(VALUE self)
 	VALUE results = rb_ary_new2( num_rows );
 
 	for ( row = 0; row < num_rows; row++ ) {
-		VALUE row_values[num_fields];
+		PG_VARIABLE_LENGTH_ARRAY(VALUE, row_values, num_fields, PG_MAX_COLUMNS)
 
 		/* populate the row */
 		for ( field = 0; field < num_fields; field++ ) {
@@ -1176,7 +1176,7 @@ pgresult_stream_each_row(VALUE self)
 		}
 
 		for ( row = 0; row < ntuples; row++ ) {
-			VALUE row_values[nfields];
+			PG_VARIABLE_LENGTH_ARRAY(VALUE, row_values, nfields, PG_MAX_COLUMNS)
 			int field;
 
 			/* populate the row */

--- a/ext/pg_text_decoder.c
+++ b/ext/pg_text_decoder.c
@@ -314,7 +314,7 @@ pg_text_dec_identifier(t_pg_coder *conv, char *val, int len, int tuple, int fiel
 	int word_index = 0;
 	int index;
 	/* Use a buffer of the same length, as that will be the worst case */
-	char word[len + 1];
+	PG_VARIABLE_LENGTH_ARRAY(char, word, len + 1, NAMEDATALEN)
 
 	/* The current character in the input string. */
 	char c;

--- a/ext/pg_type_map_by_mri_type.c
+++ b/ext/pg_type_map_by_mri_type.c
@@ -39,7 +39,7 @@ static VALUE rb_cTypeMapByMriType;
 typedef struct {
 	t_typemap typemap;
 	struct pg_tmbmt_converter {
-		FOR_EACH_MRI_TYPE( DECLARE_CODER );
+		FOR_EACH_MRI_TYPE( DECLARE_CODER )
 	} coders;
 } t_tmbmt;
 


### PR DESCRIPTION
...length arrays - notably the MSVC compiler.

This is an alternative to https://bitbucket.org/ged/ruby-pg/pull-request/20 .

Note: The MSVC build environment is currently not tested on a regular base,
so is not fully supported.