### PR TITLE
Fixing compilation problems with Microsoft Visual Studio 2008.

### DIFF
--- a/ext/extconf.rb
+++ b/ext/extconf.rb
@@ -92,6 +92,7 @@ $defs.push( "-DHAVE_ST_NOTIFY_EXTRA" ) if
 
 # unistd.h confilicts with ruby/win32.h when cross compiling for win32 and ruby 1.9.1
 have_header 'unistd.h'
+have_header 'inttypes.h'
 have_header 'ruby/st.h' or have_header 'st.h' or abort "pg currently requires the ruby/st.h header"
 
 checking_for "C99 variable length arrays" do

--- a/ext/pg_binary_decoder.c
+++ b/ext/pg_binary_decoder.c
@@ -6,7 +6,9 @@
 
 #include "pg.h"
 #include "util.h"
+#ifdef HAVE_INTTYPES_H
 #include <inttypes.h>
+#endif
 
 VALUE rb_mPG_BinaryDecoder;
 

--- a/ext/pg_binary_encoder.c
+++ b/ext/pg_binary_encoder.c
@@ -6,7 +6,9 @@
 
 #include "pg.h"
 #include "util.h"
+#ifdef HAVE_INTTYPES_H
 #include <inttypes.h>
+#endif
 
 VALUE rb_mPG_BinaryEncoder;
 

--- a/ext/pg_text_decoder.c
+++ b/ext/pg_text_decoder.c
@@ -30,7 +30,9 @@
 
 #include "pg.h"
 #include "util.h"
+#ifdef HAVE_INTTYPES_H
 #include <inttypes.h>
+#endif
 
 VALUE rb_mPG_TextDecoder;
 static ID s_id_decode;

--- a/ext/pg_text_encoder.c
+++ b/ext/pg_text_encoder.c
@@ -41,7 +41,9 @@
 
 #include "pg.h"
 #include "util.h"
+#ifdef HAVE_INTTYPES_H
 #include <inttypes.h>
+#endif
 #include <math.h>
 
 VALUE rb_mPG_TextEncoder;

--- a/ext/pg_type_map.c
+++ b/ext/pg_type_map.c
@@ -54,12 +54,12 @@ pg_typemap_typecast_copy_get( t_typemap *p_typemap, VALUE field_str, int fieldno
 }
 
 const struct pg_typemap_funcs pg_typemap_funcs = {
-	.fit_to_result = pg_typemap_fit_to_result,
-	.fit_to_query = pg_typemap_fit_to_query,
-	.fit_to_copy_get = pg_typemap_fit_to_copy_get,
-	.typecast_result_value = pg_typemap_result_value,
-	.typecast_query_param = pg_typemap_typecast_query_param,
-	.typecast_copy_get = pg_typemap_typecast_copy_get
+	pg_typemap_fit_to_result,
+	pg_typemap_fit_to_query,
+	pg_typemap_fit_to_copy_get,
+	pg_typemap_result_value,
+	pg_typemap_typecast_query_param,
+	pg_typemap_typecast_copy_get
 };
 
 static VALUE

--- a/ext/pg_type_map_by_column.c
+++ b/ext/pg_type_map_by_column.c
@@ -162,12 +162,12 @@ pg_tmbc_typecast_copy_get( t_typemap *p_typemap, VALUE field_str, int fieldno, i
 }
 
 const struct pg_typemap_funcs pg_tmbc_funcs = {
-	.fit_to_result = pg_tmbc_fit_to_result,
-	.fit_to_query = pg_tmbc_fit_to_query,
-	.fit_to_copy_get = pg_tmbc_fit_to_copy_get,
-	.typecast_result_value = pg_tmbc_result_value,
-	.typecast_query_param = pg_tmbc_typecast_query_param,
-	.typecast_copy_get = pg_tmbc_typecast_copy_get
+	pg_tmbc_fit_to_result,
+	pg_tmbc_fit_to_query,
+	pg_tmbc_fit_to_copy_get,
+	pg_tmbc_result_value,
+	pg_tmbc_typecast_query_param,
+	pg_tmbc_typecast_copy_get
 };
 
 static void


### PR DESCRIPTION
- inttypes.h is not available in MSVC 2008
- Structs members must be initialized implicitly