### PR TITLE
Respect character encoding of all strings sent to the server.

### DIFF
--- a/ext/pg.h
+++ b/ext/pg.h
@@ -205,7 +205,7 @@ typedef struct {
 } t_pg_result;
 
 
-typedef int (* t_pg_coder_enc_func)(t_pg_coder *, VALUE, char *, VALUE *);
+typedef int (* t_pg_coder_enc_func)(t_pg_coder *, VALUE, char *, VALUE *, int);
 typedef VALUE (* t_pg_coder_dec_func)(t_pg_coder *, char *, int, int, int, int);
 typedef VALUE (* t_pg_fit_to_result)(VALUE, VALUE);
 typedef VALUE (* t_pg_fit_to_query)(VALUE, VALUE);
@@ -321,8 +321,8 @@ void init_pg_binary_decoder                            _(( void ));
 VALUE lookup_error_class                               _(( const char * ));
 VALUE pg_bin_dec_bytea                                 _(( t_pg_coder*, char *, int, int, int, int ));
 VALUE pg_text_dec_string                               _(( t_pg_coder*, char *, int, int, int, int ));
-int pg_coder_enc_to_s                                  _(( t_pg_coder*, VALUE, char *, VALUE *));
-int pg_text_enc_identifier                             _(( t_pg_coder*, VALUE, char *, VALUE *));
+int pg_coder_enc_to_s                                  _(( t_pg_coder*, VALUE, char *, VALUE *, int));
+int pg_text_enc_identifier                             _(( t_pg_coder*, VALUE, char *, VALUE *, int));
 t_pg_coder_enc_func pg_coder_enc_func                  _(( t_pg_coder* ));
 t_pg_coder_dec_func pg_coder_dec_func                  _(( t_pg_coder*, int ));
 void pg_define_coder                                   _(( const char *, void *, VALUE, VALUE ));

--- a/ext/pg_binary_encoder.c
+++ b/ext/pg_binary_encoder.c
@@ -22,7 +22,7 @@ VALUE rb_mPG_BinaryEncoder;
  *
  */
 static int
-pg_bin_enc_boolean(t_pg_coder *conv, VALUE value, char *out, VALUE *intermediate)
+pg_bin_enc_boolean(t_pg_coder *conv, VALUE value, char *out, VALUE *intermediate, int enc_idx)
 {
 	char mybool;
 	switch(value){
@@ -44,7 +44,7 @@ pg_bin_enc_boolean(t_pg_coder *conv, VALUE value, char *out, VALUE *intermediate
  *
  */
 static int
-pg_bin_enc_int2(t_pg_coder *conv, VALUE value, char *out, VALUE *intermediate)
+pg_bin_enc_int2(t_pg_coder *conv, VALUE value, char *out, VALUE *intermediate, int enc_idx)
 {
 	if(out){
 		write_nbo16(NUM2INT(*intermediate), out);
@@ -63,7 +63,7 @@ pg_bin_enc_int2(t_pg_coder *conv, VALUE value, char *out, VALUE *intermediate)
  *
  */
 static int
-pg_bin_enc_int4(t_pg_coder *conv, VALUE value, char *out, VALUE *intermediate)
+pg_bin_enc_int4(t_pg_coder *conv, VALUE value, char *out, VALUE *intermediate, int enc_idx)
 {
 	if(out){
 		write_nbo32(NUM2LONG(*intermediate), out);
@@ -82,7 +82,7 @@ pg_bin_enc_int4(t_pg_coder *conv, VALUE value, char *out, VALUE *intermediate)
  *
  */
 static int
-pg_bin_enc_int8(t_pg_coder *conv, VALUE value, char *out, VALUE *intermediate)
+pg_bin_enc_int8(t_pg_coder *conv, VALUE value, char *out, VALUE *intermediate, int enc_idx)
 {
 	if(out){
 		write_nbo64(NUM2LL(*intermediate), out);
@@ -100,7 +100,7 @@ pg_bin_enc_int8(t_pg_coder *conv, VALUE value, char *out, VALUE *intermediate)
  *
  */
 static int
-pg_bin_enc_from_base64(t_pg_coder *conv, VALUE value, char *out, VALUE *intermediate)
+pg_bin_enc_from_base64(t_pg_coder *conv, VALUE value, char *out, VALUE *intermediate, int enc_idx)
 {
 	int strlen;
 	VALUE subint;
@@ -109,13 +109,13 @@ pg_bin_enc_from_base64(t_pg_coder *conv, VALUE value, char *out, VALUE *intermed
 
 	if(out){
 		/* Second encoder pass, if required */
-		strlen = enc_func(this->elem, value, out, intermediate);
+		strlen = enc_func(this->elem, value, out, intermediate, enc_idx);
 		strlen = base64_decode( out, out, strlen );
 
 		return strlen;
 	} else {
 		/* First encoder pass */
-		strlen = enc_func(this->elem, value, NULL, &subint);
+		strlen = enc_func(this->elem, value, NULL, &subint, enc_idx);
 
 		if( strlen == -1 ){
 			/* Encoded string is returned in subint */

--- a/spec/pg/type_map_by_class_spec.rb
+++ b/spec/pg/type_map_by_class_spec.rb
@@ -102,7 +102,7 @@ describe PG::TypeMapByClass do
 
 	it "should allow mixed type conversions" do
 		res = @conn.exec_params( "SELECT $1, $2, $3", [5, 1.23, :TestSymbol], 0, tm )
-		expect( res.values ).to eq([['5', '1.23', '[:TestSymbol]']])
+		expect( res.values ).to eq([['5', '1.23', "[:TestSymbol, #{@conn.internal_encoding.inspect}]"]])
 		expect( res.ftype(0) ).to eq(20)
 	end
 

--- a/spec/pg/type_map_by_mri_type_spec.rb
+++ b/spec/pg/type_map_by_mri_type_spec.rb
@@ -116,7 +116,7 @@ describe PG::TypeMapByMriType do
 
 	it "should allow mixed type conversions" do
 		res = @conn.exec_params( "SELECT $1, $2, $3", [5, 1.23, :TestSymbol], 0, tm )
-		expect( res.values ).to eq([['5', '1.23', '[:TestSymbol]']])
+		expect( res.values ).to eq([['5', '1.23', "[:TestSymbol, #{@conn.internal_encoding.inspect}]"]])
 		expect( res.ftype(0) ).to eq(20)
 	end
 


### PR DESCRIPTION
Previously all strings sent to the server were sent in their internal binary representation, without respecting the character encoding of strings. Now the encoding of all strings is compared with the current connection encoding and converted if they are different.

Since coders are independent from any database connection, this adds a second parameter to `PG::Coder#encode`, that allows to define the destination encoding, which previously was always ASCII_8BIT. This encoding should be set to the connection encoding, in practice.

This also adds a lot of tests regarding the character encoding while encoding and decoding data.

This implements issue #231 : https://bitbucket.org/ged/ruby-pg/issues/231

@ged Any objections to merge this for 0.19.0 ?