### PR TITLE
update version OpenSSL

### DIFF
--- a/Rakefile.cross
+++ b/Rakefile.cross
@@ -29,7 +29,7 @@ class CrossLibrary < OpenStruct
 		self.host_platform              = toolchain
 
 		# Cross-compilation constants
-		self.openssl_version            = ENV['OPENSSL_VERSION'] || '1.0.2e'
+		self.openssl_version            = ENV['OPENSSL_VERSION'] || '1.0.2f'
 		self.postgresql_version         = ENV['POSTGRESQL_VERSION'] || '9.5.0'
 
 		# Check if symlinks work in the current working directory.


### PR DESCRIPTION
I updated OpenSSL version `1.0.2f` from `1.0.2e` because `OpenSSL 1.0.2e` is disappeared.

After this pull request is merged, a failed pull request, https://github.com/ged/ruby-pg/pull/12, and other pull requests will be passed.