### PR TITLE
Add notation Ruby 2.2 "or newer"

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -37,7 +37,7 @@ A small example usage:
 
 == Requirements
 
-* Ruby 2.2
+* Ruby 2.2 or newer
 * PostgreSQL 9.1.x or later (with headers, -dev packages, etc).
 
 It usually work with earlier versions of Ruby/PostgreSQL as well, but those are
@@ -165,4 +165,3 @@ to this library over the years.
 
 We are thankful to the people at the ruby-list and ruby-dev mailing lists.
 And to the people who developed PostgreSQL.
-


### PR DESCRIPTION
Since Ruby 2.3.0 and Ruby 2.4 was released, I added it.

However, I do not understand well that the following points.
In this repository, there are mixed descriptions that can be read as Ruby 2.0 and Ruby 2.2.

examples:
 - Bitbucket(Home): [Ruby 2.0 or newer](https://bitbucket.org/ged/ruby-pg/wiki/Home#markdown-header-requirements)
 - GitHub(README): [Ruby 2.2](https://github.com/ged/ruby-pg/blob/master/README.rdoc#requirements)  
 - .travis.yml: [Ruby 2.2, 2.3.0 tested](https://github.com/ged/ruby-pg/blob/fa0f29affc8eb850ee9ddb972a46ade7fc32195e/.travis.yml#L6-L7)
 - pg.gemspec: [Ruby 2.0.0 required](https://github.com/ged/ruby-pg/blob/fa0f29affc8eb850ee9ddb972a46ade7fc32195e/pg.gemspec#L22)

 I speculated "Ruby 2.2 or newer" from the below change
 - https://github.com/ged/ruby-pg/commit/a1c31e2a2f3100b9075f07af5477aa9262dc6767

 Thanks!