### PR TITLE
Check if the argument for #Connection is an URI

### DIFF
--- a/lib/pg/connection.rb
+++ b/lib/pg/connection.rb
@@ -47,7 +47,7 @@ class PG::Connection
 
 		if args.length == 1
 			case args.first
-			when URI, URI.regexp
+			when URI, /\A#{URI.regexp}\z/
 				uri = URI(args.first)
 				options.merge!( Hash[URI.decode_www_form( uri.query )] ) if uri.query
 			when /=/

--- a/spec/pg/connection_spec.rb
+++ b/spec/pg/connection_spec.rb
@@ -119,6 +119,19 @@ describe PG::Connection do
 	end
 
 	it "connects successfully with connection string" do
+		conninfo_with_colon_in_password = "host=localhost user=a port=555 dbname=test password=a:a"
+
+		string = described_class.parse_connect_args( conninfo_with_colon_in_password )
+
+		expect( string ).to be_a( String )
+		expect( string ).to match( %r{(^|\s)user=a} )
+		expect( string ).to match( %r{(^|\s)password=a:a} )
+		expect( string ).to match( %r{(^|\s)host=localhost} )
+		expect( string ).to match( %r{(^|\s)port=555} )
+		expect( string ).to match( %r{(^|\s)dbname=test} )
+	end
+
+	it "connects successfully with connection string" do
 		tmpconn = described_class.connect( @conninfo )
 		expect( tmpconn.status ).to eq( PG::CONNECTION_OK )
 		tmpconn.finish


### PR DESCRIPTION
Previously the code checked if the argument
contained an URI instead of being one. This
caused some connection strings being mis-
dected as connection URI's.

fixes #265  ( https://bitbucket.org/ged/ruby-pg/issues/265/colon-not-allowed-in-a-connection-string )