### PR TITLE
Specify test directory by environment variable.

### DIFF
--- a/spec/helpers.rb
+++ b/spec/helpers.rb
@@ -5,7 +5,9 @@ require 'rspec'
 require 'shellwords'
 require 'pg'
 
-TEST_DIRECTORY = Pathname.getwd + "tmp_test_specs"
+DEFAULT_TEST_DIR_STR = File.join(Dir.pwd, "tmp_test_specs")
+TEST_DIR_STR = ENV['RUBY_PG_TEST_DIR'] || DEFAULT_TEST_DIR_STR
+TEST_DIRECTORY = Pathname.new(TEST_DIR_STR)
 
 module PG::TestingHelpers
 


### PR DESCRIPTION
Hi,

I am working for this `ruby-pg`'s RPM package on Fedora Project [1] and Red Hat.

I have to build your package on very long path working directory (`/builddir/build/BUILD/pg-0.21.0/opt/rh/rh-ruby25/root/usr/share/gems/gems/pg-0.21.0`) because of our build system.

And that causes PostgreSQL failed to start.

Below is the `setup.log` log file.

```
$ cat tmp_test_specs/setup.log
...
    pg_ctl -D /builddir/build/BUILD/pg-0.21.0/opt/rh/rh-ruby25/root/usr/share/gems/gems/pg-0.21.0/tmp_test_specs/data -l logfile start

waiting for server to start....LOG:  Unix-domain socket path "/builddir/build/BUILD/pg-0.21.0/opt/rh/rh-ruby25/root/usr/share/gems/gems/pg-0.21.0/tmp_test_specs/.s.PGSQL.54321" is too long (maximum 107 bytes)
```

So, I want to specify the test directory by environment variable.
If not specified, the current testing directory is used as a default behavior.

```
$ RUBY_PG_TEST_DIRECTORY=/tmp/tmp_test_specs bundle exec rake compile test

$ ls /tmp/tmp_test_specs/
data/  setup.log  test_trace.out
```

Is it possible to merge?
That helps me.

Thanks.


[1] https://src.fedoraproject.org/rpms/rubygem-pg
