### PR TITLE
Faster time decoder

### DIFF
--- a/ext/extconf.rb
+++ b/ext/extconf.rb
@@ -76,6 +76,7 @@ have_func 'PQsetSingleRowMode' or
 have_func 'PQconninfo'
 have_func 'PQsslAttribute'
 have_func 'PQencryptPasswordConn'
+have_func 'timegm'
 
 have_const 'PG_DIAG_TABLE_NAME', 'libpq-fe.h'
 

--- a/ext/pg_text_decoder.c
+++ b/ext/pg_text_decoder.c
@@ -535,7 +535,7 @@ static VALUE pg_text_decoder_timestamp_do(t_pg_coder *conv, char *val, int len, 
     int tz_hour = 0;
     int tz_min = 0;
     int tz_sec = 0;
- 
+
     year = str4_to_int(&str[0]);
     mon = str2_to_int(&str[5]);
     day = str2_to_int(&str[8]);
@@ -543,7 +543,7 @@ static VALUE pg_text_decoder_timestamp_do(t_pg_coder *conv, char *val, int len, 
     min = str2_to_int(&str[14]);
     sec = str2_to_int(&str[17]);
     str += 19;
- 
+
     if (str[0] == '.' && isdigit(str[1]))
     {
       /* nano second part, up to 9 digits */
@@ -558,6 +558,8 @@ static VALUE pg_text_decoder_timestamp_do(t_pg_coder *conv, char *val, int len, 
       {
         nsec += coef[i] * char_to_digit(*str++);
       }
+      /* consume digits smaller than nsec */
+      while(isdigit(*str)) str++;
     }
 
     if (with_timezone)

--- a/ext/pg_text_decoder.c
+++ b/ext/pg_text_decoder.c
@@ -589,7 +589,7 @@ static VALUE pg_text_decoder_timestamp_do(t_pg_coder *conv, char *val, int len, 
     }
     if (*str == '\0')
     {
-#if RUBY_API_VERSION_MAJOR > 2 || (RUBY_API_VERSION_MAJOR == 2 && RUBY_API_VERSION_MINOR >= 3)
+#if RUBY_API_VERSION_MAJOR > 2 || (RUBY_API_VERSION_MAJOR == 2 && RUBY_API_VERSION_MINOR >= 3) && !defined(_WIN32)
       // must have consumed all the string
       struct tm tm;
       tm.tm_year = year - 1900;
@@ -602,16 +602,7 @@ static VALUE pg_text_decoder_timestamp_do(t_pg_coder *conv, char *val, int len, 
 
       if (with_timezone)
       {
-#ifdef _WIN32
-        /* we can't use _mkgmtime because it is not available when using mingw32 */
-        time_t time;
-        time_t prevTZ = _timezone;
-        _timezone = 0;
-        time = mktime(&tm);
-        _timezone = prevTZ;
-#else
         time_t time = timegm(&tm);
-#endif
         if (time != -1)
         {
           struct timespec ts;

--- a/ext/pg_text_decoder.c
+++ b/ext/pg_text_decoder.c
@@ -39,6 +39,8 @@
 
 VALUE rb_mPG_TextDecoder;
 static ID s_id_decode;
+static ID s_id_Rational;
+static ID s_id_new;
 
 /*
  * Document-class: PG::TextDecoder::Boolean < PG::SimpleDecoder
@@ -637,7 +639,7 @@ static VALUE pg_text_decoder_timestamp_do(t_pg_coder *conv, char *val, int len, 
       {
         int sec_numerator = sec * 1000000 + nsec / 1000;
         int sec_denominator = 1000000;
-        sec_value = rb_funcall(Qnil, rb_intern("Rational"), 2,
+        sec_value = rb_funcall(Qnil, s_id_Rational, 2,
             INT2NUM(sec_numerator), INT2NUM(sec_denominator));
       }
       else
@@ -655,7 +657,7 @@ static VALUE pg_text_decoder_timestamp_do(t_pg_coder *conv, char *val, int len, 
         }
         gmt_offset_value = INT2NUM(gmt_offset);
       }
-      return rb_funcall(rb_cTime, rb_intern("new"), 7,
+      return rb_funcall(rb_cTime, s_id_new, 7,
           INT2NUM(year),
           INT2NUM(mon),
           INT2NUM(day),
@@ -685,6 +687,8 @@ void
 init_pg_text_decoder()
 {
 	s_id_decode = rb_intern("decode");
+	s_id_Rational = rb_intern("Rational");
+	s_id_new = rb_intern("new");
 
 	/* This module encapsulates all decoder classes with text input format */
 	rb_mPG_TextDecoder = rb_define_module_under( rb_mPG, "TextDecoder" );

--- a/ext/pg_text_decoder.c
+++ b/ext/pg_text_decoder.c
@@ -524,6 +524,8 @@ static int str2_to_int(const char *str)
 
 static VALUE pg_text_decoder_timestamp_do(const char *str, int len, int tuple, int field, int with_timezone)
 {
+  const char *rstr = str;
+
   if (isdigit(str[0]) && isdigit(str[1]) && isdigit(str[2]) && isdigit(str[3])
    && str[4] == '-'
    && isdigit(str[5]) && isdigit(str[6])
@@ -640,7 +642,7 @@ static VALUE pg_text_decoder_timestamp_do(const char *str, int len, int tuple, i
       }
     }
   }
-  rb_raise( rb_eTypeError, "wrong data for %s converter in tuple %d field %d length %d", with_timezone ? "TimestampWithTimeZone" : "TimestampWithoutTimeZOne", tuple, field, len);
+  return rb_tainted_str_new(rstr, len);
 }
 
 static VALUE

--- a/ext/pg_text_decoder.c
+++ b/ext/pg_text_decoder.c
@@ -40,8 +40,6 @@
 VALUE rb_mPG_TextDecoder;
 static ID s_id_decode;
 
-extern VALUE rb_cTime;
-
 /*
  * Document-class: PG::TextDecoder::Boolean < PG::SimpleDecoder
  *

--- a/ext/pg_text_decoder.c
+++ b/ext/pg_text_decoder.c
@@ -28,10 +28,26 @@
  *
  */
 
+#include "ruby/version.h"
 #include "pg.h"
 #include "util.h"
 #ifdef HAVE_INTTYPES_H
 #include <inttypes.h>
+#endif
+
+#ifdef RUBY_API_VERSION_MAJOR
+#       if RUBY_API_VERSION_MAJOR > 2 || (RUBY_API_VERSION_MAJOR == 2 && RUBY_API_VERSION_MINOR >= 3)
+                /* use C implementation of the SimpleDecoder`s timestamp function
+                 * when using ruby >= 2.3 */
+#               define PG_TEXT_DECODER_TIMESTAMP_EXT
+#       endif
+#endif
+
+#ifdef PG_TEXT_DECODER_TIMESTAMP_EXT
+#       include <ctype.h>
+#       include <time.h>
+static VALUE rb_cPG_TimestampWithTimeZone;
+static VALUE rb_cPG_TimestampWithoutTimeZone;
 #endif
 
 VALUE rb_mPG_TextDecoder;
@@ -488,6 +504,180 @@ pg_text_dec_from_base64(t_pg_coder *conv, char *val, int len, int tuple, int fie
 	return out_value;
 }
 
+#ifdef PG_TEXT_DECODER_TIMESTAMP_EXT
+static inline int char_to_digit(char c)
+{
+  return c - '0';
+}
+
+static int str4_to_int(const char *str)
+{
+  return char_to_digit(str[0]) * 1000
+       + char_to_digit(str[1]) * 100
+       + char_to_digit(str[2]) * 10
+       + char_to_digit(str[3]);
+}
+
+static int str2_to_int(const char *str)
+{
+  return char_to_digit(str[0]) * 10
+       + char_to_digit(str[1]);
+}
+
+static VALUE pg_text_decoder_timestamp_do(VALUE rstr, int with_timezone)
+{
+  const char *str = StringValuePtr(rstr);
+
+  if (isdigit(str[0]) && isdigit(str[1]) && isdigit(str[2]) && isdigit(str[3])
+   && str[4] == '-'
+   && isdigit(str[5]) && isdigit(str[6])
+   && str[7] == '-'
+   && isdigit(str[8]) && isdigit(str[9])
+   && str[10] == ' '
+   && isdigit(str[11]) && isdigit(str[12])
+   && str[13] == ':'
+   && isdigit(str[14]) && isdigit(str[15])
+   && str[16] == ':'
+   && isdigit(str[17]) && isdigit(str[18])
+  )
+  {
+    struct tm tm;
+    int nsec = 0;
+    int tz_neg = 0;
+    int tz_hour = 0;
+    int tz_min = 0;
+    int tz_sec = 0;
+ 
+    tm.tm_year = str4_to_int(&str[0]) - 1900;
+    tm.tm_mon = str2_to_int(&str[5]) - 1;
+    tm.tm_mday = str2_to_int(&str[8]);
+    tm.tm_hour = str2_to_int(&str[11]);
+    tm.tm_min = str2_to_int(&str[14]);
+    tm.tm_sec = str2_to_int(&str[17]);
+    tm.tm_isdst = 0;
+    str += 19;
+ 
+    if (str[0] == '.' && isdigit(str[1]))
+    {
+      /* nano second part, up to 9 digits */
+      static const int coef[9] = {
+        100000000, 10000000, 1000000,
+        100000, 10000, 1000, 100, 10, 1
+      };
+      int i;
+
+      str++;
+      for (i = 0; i < 9 && isdigit(*str); i++)
+      {
+        nsec += coef[i] * char_to_digit(*str++);
+      }
+    }
+
+    if (with_timezone)
+    {
+      if ((str[0] == '+' || str[0] == '-') && isdigit(str[1]) && isdigit(str[2]))
+      {
+        tz_neg = str[0] == '-';
+        tz_hour = str2_to_int(&str[1]);
+        str += 3;
+      }
+      if (str[0] == ':')
+      {
+        str++;
+      }
+      if (isdigit(str[0]) && isdigit(str[1]))
+      {
+        tz_min = str2_to_int(str);
+        str += 2;
+      }
+      if (str[0] == ':')
+      {
+        str++;
+      }
+      if (isdigit(str[0]) && isdigit(str[1]))
+      {
+        tz_sec = str2_to_int(str);
+        str += 2;
+      }
+    }
+    if (*str != '\0')
+    {
+      // not consumed all the string
+      return rstr;
+    }
+
+    if (with_timezone)
+    {
+#ifdef _WIN32
+      /* we can't use _mkgmtime because it is not available when using mingw32 */
+      time_t time;
+      time_t prevTZ = _timezone;
+      _timezone = 0;
+      time = mktime(&tm);
+      _timezone = prevTZ;
+#else
+      time_t time = timegm(&tm);
+#endif
+      if (time != -1)
+      {
+        struct timespec ts;
+        int gmt_offset;
+
+        gmt_offset = tz_hour * 3600 + tz_min * 60 + tz_sec;
+        if (tz_neg)
+        {
+          gmt_offset = - gmt_offset;
+        }
+        ts.tv_sec = time - gmt_offset;
+        ts.tv_nsec = nsec;
+        return rb_time_timespec_new(&ts, gmt_offset);
+      }
+    }
+    else
+    {
+      time_t time = mktime(&tm);
+      if (time != -1)
+      {
+        struct timespec ts;
+
+        ts.tv_sec = time;
+        ts.tv_nsec = nsec;
+        return rb_time_timespec_new(&ts, 0);
+      }
+    }
+  }
+  return rstr;
+}
+
+static VALUE
+pg_text_dec_timestamp_with_time_zone(int argc, VALUE *argv, VALUE self)
+{
+  if (argc < 1 || argc > 3)
+  {
+        rb_raise(rb_eArgError, "wrong number of arguments (%i for 1..3)", argc);
+  }
+  if (NIL_P(argv[0]))
+  {
+        return Qnil;
+  }
+  return pg_text_decoder_timestamp_do(argv[0], 1);
+}
+
+static VALUE
+pg_text_dec_timestamp_without_time_zone(int argc, VALUE *argv, VALUE self)
+{
+  if (argc < 1 || argc > 3)
+  {
+        rb_raise(rb_eArgError, "wrong number of arguments (%i for 1..3)", argc);
+  }
+  if (NIL_P(argv[0]))
+  {
+        return Qnil;
+  }
+  return pg_text_decoder_timestamp_do(argv[0], 0);
+}
+#endif
+
 void
 init_pg_text_decoder()
 {
@@ -514,4 +704,14 @@ init_pg_text_decoder()
 	pg_define_coder( "Array", pg_text_dec_array, rb_cPG_CompositeDecoder, rb_mPG_TextDecoder );
 	/* dummy = rb_define_class_under( rb_mPG_TextDecoder, "FromBase64", rb_cPG_CompositeDecoder ); */
 	pg_define_coder( "FromBase64", pg_text_dec_from_base64, rb_cPG_CompositeDecoder, rb_mPG_TextDecoder );
+
+#ifdef PG_TEXT_DECODER_TIMESTAMP_EXT
+        /* Document-class: PG::TimestampWithTimeZone < PG::SimpleDecoder */
+        rb_cPG_TimestampWithTimeZone = rb_define_class_under( rb_mPG_TextDecoder, "TimestampWithTimeZone", rb_cPG_SimpleDecoder );
+        rb_define_method( rb_cPG_TimestampWithTimeZone, "decode", pg_text_dec_timestamp_with_time_zone, -1 );
+ 
+        /* Document-class: PG::TimestampWithoutTimeZone < PG::SimpleDecoder */
+        rb_cPG_TimestampWithoutTimeZone = rb_define_class_under( rb_mPG_TextDecoder, "TimestampWithoutTimeZone", rb_cPG_SimpleDecoder );
+        rb_define_method( rb_cPG_TimestampWithoutTimeZone, "decode", pg_text_dec_timestamp_without_time_zone, -1 );
+#endif
 }

--- a/ext/pg_text_decoder.c
+++ b/ext/pg_text_decoder.c
@@ -511,9 +511,9 @@ static int str2_to_int(const char *str)
        + char_to_digit(str[1]);
 }
 
-static VALUE pg_text_decoder_timestamp_do(const char *str, int len, int tuple, int field, int with_timezone)
+static VALUE pg_text_decoder_timestamp_do(t_pg_coder *conv, char *val, int len, int tuple, int field, int enc_idx, int with_timezone)
 {
-  const char *rstr = str;
+  const char *str = val;
 
   if (isdigit(str[0]) && isdigit(str[1]) && isdigit(str[2]) && isdigit(str[3])
    && str[4] == '-'
@@ -675,19 +675,19 @@ static VALUE pg_text_decoder_timestamp_do(const char *str, int len, int tuple, i
 #endif
     }
   }
-  return rb_tainted_str_new(rstr, len);
+  return pg_text_dec_string(conv, val, len, tuple, field, enc_idx);
 }
 
 static VALUE
 pg_text_dec_timestamp_with_time_zone(t_pg_coder *conv, char *val, int len, int tuple, int field, int enc_idx)
 {
-  return pg_text_decoder_timestamp_do(val, len, tuple, field, 1);
+  return pg_text_decoder_timestamp_do(conv, val, len, tuple, field, enc_idx, 1);
 }
 
 static VALUE
 pg_text_dec_timestamp_without_time_zone(t_pg_coder *conv, char *val, int len, int tuple, int field, int enc_idx)
 {
-  return pg_text_decoder_timestamp_do(val, len, tuple, field, 0);
+  return pg_text_decoder_timestamp_do(conv, val, len, tuple, field, enc_idx, 0);
 }
 
 void

--- a/ext/pg_text_decoder.c
+++ b/ext/pg_text_decoder.c
@@ -494,193 +494,193 @@ pg_text_dec_from_base64(t_pg_coder *conv, char *val, int len, int tuple, int fie
 
 static inline int char_to_digit(char c)
 {
-  return c - '0';
+	return c - '0';
 }
 
 static int str4_to_int(const char *str)
 {
-  return char_to_digit(str[0]) * 1000
-       + char_to_digit(str[1]) * 100
-       + char_to_digit(str[2]) * 10
-       + char_to_digit(str[3]);
+	return char_to_digit(str[0]) * 1000
+			+ char_to_digit(str[1]) * 100
+			+ char_to_digit(str[2]) * 10
+			+ char_to_digit(str[3]);
 }
 
 static int str2_to_int(const char *str)
 {
-  return char_to_digit(str[0]) * 10
-       + char_to_digit(str[1]);
+	return char_to_digit(str[0]) * 10
+			+ char_to_digit(str[1]);
 }
 
 static VALUE pg_text_decoder_timestamp_do(t_pg_coder *conv, char *val, int len, int tuple, int field, int enc_idx, int with_timezone)
 {
-  const char *str = val;
+	const char *str = val;
 
-  if (isdigit(str[0]) && isdigit(str[1]) && isdigit(str[2]) && isdigit(str[3])
-   && str[4] == '-'
-   && isdigit(str[5]) && isdigit(str[6])
-   && str[7] == '-'
-   && isdigit(str[8]) && isdigit(str[9])
-   && str[10] == ' '
-   && isdigit(str[11]) && isdigit(str[12])
-   && str[13] == ':'
-   && isdigit(str[14]) && isdigit(str[15])
-   && str[16] == ':'
-   && isdigit(str[17]) && isdigit(str[18])
-  )
-  {
-    int year, mon, day;
-    int hour, min, sec;
-    int nsec = 0;
-    int tz_neg = 0;
-    int tz_hour = 0;
-    int tz_min = 0;
-    int tz_sec = 0;
+	if (isdigit(str[0]) && isdigit(str[1]) && isdigit(str[2]) && isdigit(str[3])
+	&& str[4] == '-'
+	&& isdigit(str[5]) && isdigit(str[6])
+	&& str[7] == '-'
+	&& isdigit(str[8]) && isdigit(str[9])
+	&& str[10] == ' '
+	&& isdigit(str[11]) && isdigit(str[12])
+	&& str[13] == ':'
+	&& isdigit(str[14]) && isdigit(str[15])
+	&& str[16] == ':'
+	&& isdigit(str[17]) && isdigit(str[18])
+	)
+	{
+		int year, mon, day;
+		int hour, min, sec;
+		int nsec = 0;
+		int tz_neg = 0;
+		int tz_hour = 0;
+		int tz_min = 0;
+		int tz_sec = 0;
 
-    year = str4_to_int(&str[0]);
-    mon = str2_to_int(&str[5]);
-    day = str2_to_int(&str[8]);
-    hour = str2_to_int(&str[11]);
-    min = str2_to_int(&str[14]);
-    sec = str2_to_int(&str[17]);
-    str += 19;
+		year = str4_to_int(&str[0]);
+		mon = str2_to_int(&str[5]);
+		day = str2_to_int(&str[8]);
+		hour = str2_to_int(&str[11]);
+		min = str2_to_int(&str[14]);
+		sec = str2_to_int(&str[17]);
+		str += 19;
 
-    if (str[0] == '.' && isdigit(str[1]))
-    {
-      /* nano second part, up to 9 digits */
-      static const int coef[9] = {
-        100000000, 10000000, 1000000,
-        100000, 10000, 1000, 100, 10, 1
-      };
-      int i;
+		if (str[0] == '.' && isdigit(str[1]))
+		{
+			/* nano second part, up to 9 digits */
+			static const int coef[9] = {
+				100000000, 10000000, 1000000,
+				100000, 10000, 1000, 100, 10, 1
+			};
+			int i;
 
-      str++;
-      for (i = 0; i < 9 && isdigit(*str); i++)
-      {
-        nsec += coef[i] * char_to_digit(*str++);
-      }
-      /* consume digits smaller than nsec */
-      while(isdigit(*str)) str++;
-    }
+			str++;
+			for (i = 0; i < 9 && isdigit(*str); i++)
+			{
+				nsec += coef[i] * char_to_digit(*str++);
+			}
+			/* consume digits smaller than nsec */
+			while(isdigit(*str)) str++;
+		}
 
-    if (with_timezone)
-    {
-      if ((str[0] == '+' || str[0] == '-') && isdigit(str[1]) && isdigit(str[2]))
-      {
-        tz_neg = str[0] == '-';
-        tz_hour = str2_to_int(&str[1]);
-        str += 3;
-      }
-      if (str[0] == ':')
-      {
-        str++;
-      }
-      if (isdigit(str[0]) && isdigit(str[1]))
-      {
-        tz_min = str2_to_int(str);
-        str += 2;
-      }
-      if (str[0] == ':')
-      {
-        str++;
-      }
-      if (isdigit(str[0]) && isdigit(str[1]))
-      {
-        tz_sec = str2_to_int(str);
-        str += 2;
-      }
-    }
-    if (*str == '\0')
-    {
+		if (with_timezone)
+		{
+			if ((str[0] == '+' || str[0] == '-') && isdigit(str[1]) && isdigit(str[2]))
+			{
+				tz_neg = str[0] == '-';
+				tz_hour = str2_to_int(&str[1]);
+				str += 3;
+			}
+			if (str[0] == ':')
+			{
+				str++;
+			}
+			if (isdigit(str[0]) && isdigit(str[1]))
+			{
+				tz_min = str2_to_int(str);
+				str += 2;
+			}
+			if (str[0] == ':')
+			{
+				str++;
+			}
+			if (isdigit(str[0]) && isdigit(str[1]))
+			{
+				tz_sec = str2_to_int(str);
+				str += 2;
+			}
+		}
+		if (*str == '\0')
+		{
 #if RUBY_API_VERSION_MAJOR > 2 || (RUBY_API_VERSION_MAJOR == 2 && RUBY_API_VERSION_MINOR >= 3) && !defined(_WIN32)
-      // must have consumed all the string
-      struct tm tm;
-      tm.tm_year = year - 1900;
-      tm.tm_mon = mon - 1;
-      tm.tm_mday = day;
-      tm.tm_hour = hour;
-      tm.tm_min = min;
-      tm.tm_sec = sec;
-      tm.tm_isdst = 0;
+			// must have consumed all the string
+			struct tm tm;
+			tm.tm_year = year - 1900;
+			tm.tm_mon = mon - 1;
+			tm.tm_mday = day;
+			tm.tm_hour = hour;
+			tm.tm_min = min;
+			tm.tm_sec = sec;
+			tm.tm_isdst = 0;
 
-      if (with_timezone)
-      {
-        time_t time = timegm(&tm);
-        if (time != -1)
-        {
-          struct timespec ts;
-          int gmt_offset;
+			if (with_timezone)
+			{
+				time_t time = timegm(&tm);
+				if (time != -1)
+				{
+					struct timespec ts;
+					int gmt_offset;
 
-          gmt_offset = tz_hour * 3600 + tz_min * 60 + tz_sec;
-          if (tz_neg)
-          {
-            gmt_offset = - gmt_offset;
-          }
-          ts.tv_sec = time - gmt_offset;
-          ts.tv_nsec = nsec;
-          return rb_time_timespec_new(&ts, gmt_offset);
-        }
-      }
-      else
-      {
-        time_t time = mktime(&tm);
-        if (time != -1)
-        {
-          struct timespec ts;
+					gmt_offset = tz_hour * 3600 + tz_min * 60 + tz_sec;
+					if (tz_neg)
+					{
+						gmt_offset = - gmt_offset;
+					}
+					ts.tv_sec = time - gmt_offset;
+					ts.tv_nsec = nsec;
+					return rb_time_timespec_new(&ts, gmt_offset);
+				}
+			}
+			else
+			{
+				time_t time = mktime(&tm);
+				if (time != -1)
+				{
+					struct timespec ts;
 
-          ts.tv_sec = time;
-          ts.tv_nsec = nsec;
-          return rb_time_timespec_new(&ts, 0);
-        }
-      }
+					ts.tv_sec = time;
+					ts.tv_nsec = nsec;
+					return rb_time_timespec_new(&ts, 0);
+				}
+			}
 #else
-      VALUE sec_value;
-      VALUE gmt_offset_value = Qnil;
-      if (nsec)
-      {
-        int sec_numerator = sec * 1000000 + nsec / 1000;
-        int sec_denominator = 1000000;
-        sec_value = rb_funcall(Qnil, s_id_Rational, 2,
-            INT2NUM(sec_numerator), INT2NUM(sec_denominator));
-      }
-      else
-      {
-        sec_value = INT2NUM(sec);
-      }
-      if (with_timezone)
-      {
-        int gmt_offset;
+			VALUE sec_value;
+			VALUE gmt_offset_value = Qnil;
+			if (nsec)
+			{
+				int sec_numerator = sec * 1000000 + nsec / 1000;
+				int sec_denominator = 1000000;
+				sec_value = rb_funcall(Qnil, s_id_Rational, 2,
+						INT2NUM(sec_numerator), INT2NUM(sec_denominator));
+			}
+			else
+			{
+				sec_value = INT2NUM(sec);
+			}
+			if (with_timezone)
+			{
+				int gmt_offset;
 
-        gmt_offset = tz_hour * 3600 + tz_min * 60 + tz_sec;
-        if (tz_neg)
-        {
-          gmt_offset = - gmt_offset;
-        }
-        gmt_offset_value = INT2NUM(gmt_offset);
-      }
-      return rb_funcall(rb_cTime, s_id_new, 7,
-          INT2NUM(year),
-          INT2NUM(mon),
-          INT2NUM(day),
-          INT2NUM(hour),
-          INT2NUM(min),
-          sec_value,
-          gmt_offset_value);
+				gmt_offset = tz_hour * 3600 + tz_min * 60 + tz_sec;
+				if (tz_neg)
+				{
+					gmt_offset = - gmt_offset;
+				}
+				gmt_offset_value = INT2NUM(gmt_offset);
+			}
+			return rb_funcall(rb_cTime, s_id_new, 7,
+					INT2NUM(year),
+					INT2NUM(mon),
+					INT2NUM(day),
+					INT2NUM(hour),
+					INT2NUM(min),
+					sec_value,
+					gmt_offset_value);
 #endif
-    }
-  }
-  return pg_text_dec_string(conv, val, len, tuple, field, enc_idx);
+		}
+	}
+	return pg_text_dec_string(conv, val, len, tuple, field, enc_idx);
 }
 
 static VALUE
 pg_text_dec_timestamp_with_time_zone(t_pg_coder *conv, char *val, int len, int tuple, int field, int enc_idx)
 {
-  return pg_text_decoder_timestamp_do(conv, val, len, tuple, field, enc_idx, 1);
+	return pg_text_decoder_timestamp_do(conv, val, len, tuple, field, enc_idx, 1);
 }
 
 static VALUE
 pg_text_dec_timestamp_without_time_zone(t_pg_coder *conv, char *val, int len, int tuple, int field, int enc_idx)
 {
-  return pg_text_decoder_timestamp_do(conv, val, len, tuple, field, enc_idx, 0);
+	return pg_text_decoder_timestamp_do(conv, val, len, tuple, field, enc_idx, 0);
 }
 
 void
@@ -712,9 +712,9 @@ init_pg_text_decoder()
 	/* dummy = rb_define_class_under( rb_mPG_TextDecoder, "FromBase64", rb_cPG_CompositeDecoder ); */
 	pg_define_coder( "FromBase64", pg_text_dec_from_base64, rb_cPG_CompositeDecoder, rb_mPG_TextDecoder );
 
-        /* dummy = rb_define_class_under( rb_mPG_TextDecoder, "TimestampWithTimeZone", rb_cPG_SimpleDecoder ); */
-        pg_define_coder( "TimestampWithTimeZone", pg_text_dec_timestamp_with_time_zone, rb_cPG_SimpleDecoder, rb_mPG_TextDecoder);
+				/* dummy = rb_define_class_under( rb_mPG_TextDecoder, "TimestampWithTimeZone", rb_cPG_SimpleDecoder ); */
+				pg_define_coder( "TimestampWithTimeZone", pg_text_dec_timestamp_with_time_zone, rb_cPG_SimpleDecoder, rb_mPG_TextDecoder);
 
-        /* dummy = rb_define_class_under( rb_mPG_TextDecoder, "TimestampWithoutTimeZone", rb_cPG_SimpleDecoder ); */
-        pg_define_coder( "TimestampWithoutTimeZone", pg_text_dec_timestamp_without_time_zone, rb_cPG_SimpleDecoder, rb_mPG_TextDecoder);
+				/* dummy = rb_define_class_under( rb_mPG_TextDecoder, "TimestampWithoutTimeZone", rb_cPG_SimpleDecoder ); */
+				pg_define_coder( "TimestampWithoutTimeZone", pg_text_dec_timestamp_without_time_zone, rb_cPG_SimpleDecoder, rb_mPG_TextDecoder);
 }

--- a/lib/pg/text_decoder.rb
+++ b/lib/pg/text_decoder.rb
@@ -17,32 +17,6 @@ module PG
 			end
 		end
 
-		if RUBY_VERSION < '2.3.0'
-			class TimestampWithoutTimeZone < SimpleDecoder
-				ISO_DATETIME_WITHOUT_TIMEZONE = /\A(\d{4})-(\d\d)-(\d\d) (\d\d):(\d\d):(\d\d)(\.\d+)?\z/
-
-				def decode(string, tuple=nil, field=nil)
-					if string =~ ISO_DATETIME_WITHOUT_TIMEZONE
-						Time.new $1.to_i, $2.to_i, $3.to_i, $4.to_i, $5.to_i, "#{$6}#{$7}".to_r
-					else
-						string
-					end
-				end
-			end
-
-			class TimestampWithTimeZone < SimpleDecoder
-				ISO_DATETIME_WITH_TIMEZONE = /\A(\d{4})-(\d\d)-(\d\d) (\d\d):(\d\d):(\d\d)(\.\d+)?([-\+]\d\d):?(\d\d)?:?(\d\d)?\z/
-
-				def decode(string, tuple=nil, field=nil)
-					if string =~ ISO_DATETIME_WITH_TIMEZONE
-						Time.new $1.to_i, $2.to_i, $3.to_i, $4.to_i, $5.to_i, "#{$6}#{$7}".to_r, "#{$8}:#{$9 || '00'}:#{$10 || '00'}"
-					else
-						string
-					end
-				end
-			end
-		end
-
 		class JSON < SimpleDecoder
 			def decode(string, tuple=nil, field=nil)
 				::JSON.parse(string, quirks_mode: true)

--- a/lib/pg/text_decoder.rb
+++ b/lib/pg/text_decoder.rb
@@ -17,26 +17,28 @@ module PG
 			end
 		end
 
-		class TimestampWithoutTimeZone < SimpleDecoder
-			ISO_DATETIME_WITHOUT_TIMEZONE = /\A(\d{4})-(\d\d)-(\d\d) (\d\d):(\d\d):(\d\d)(\.\d+)?\z/
+		if RUBY_VERSION < '2.3.0'
+			class TimestampWithoutTimeZone < SimpleDecoder
+				ISO_DATETIME_WITHOUT_TIMEZONE = /\A(\d{4})-(\d\d)-(\d\d) (\d\d):(\d\d):(\d\d)(\.\d+)?\z/
 
-			def decode(string, tuple=nil, field=nil)
-				if string =~ ISO_DATETIME_WITHOUT_TIMEZONE
-					Time.new $1.to_i, $2.to_i, $3.to_i, $4.to_i, $5.to_i, "#{$6}#{$7}".to_r
-				else
-					string
+				def decode(string, tuple=nil, field=nil)
+					if string =~ ISO_DATETIME_WITHOUT_TIMEZONE
+						Time.new $1.to_i, $2.to_i, $3.to_i, $4.to_i, $5.to_i, "#{$6}#{$7}".to_r
+					else
+						string
+					end
 				end
 			end
-		end
 
-		class TimestampWithTimeZone < SimpleDecoder
-			ISO_DATETIME_WITH_TIMEZONE = /\A(\d{4})-(\d\d)-(\d\d) (\d\d):(\d\d):(\d\d)(\.\d+)?([-\+]\d\d):?(\d\d)?:?(\d\d)?\z/
+			class TimestampWithTimeZone < SimpleDecoder
+				ISO_DATETIME_WITH_TIMEZONE = /\A(\d{4})-(\d\d)-(\d\d) (\d\d):(\d\d):(\d\d)(\.\d+)?([-\+]\d\d):?(\d\d)?:?(\d\d)?\z/
 
-			def decode(string, tuple=nil, field=nil)
-				if string =~ ISO_DATETIME_WITH_TIMEZONE
-					Time.new $1.to_i, $2.to_i, $3.to_i, $4.to_i, $5.to_i, "#{$6}#{$7}".to_r, "#{$8}:#{$9 || '00'}:#{$10 || '00'}"
-				else
-					string
+				def decode(string, tuple=nil, field=nil)
+					if string =~ ISO_DATETIME_WITH_TIMEZONE
+						Time.new $1.to_i, $2.to_i, $3.to_i, $4.to_i, $5.to_i, "#{$6}#{$7}".to_r, "#{$8}:#{$9 || '00'}:#{$10 || '00'}"
+					else
+						string
+					end
 				end
 			end
 		end


### PR DESCRIPTION
This moves PG::SimpleDecoder::TimestampWithTimeZone and PG::SimpleDecoder::TimestampWithoutTimeZone to C. It is based on https://github.com/ged/ruby-pg/pull/19 with some tweaking by me.

I tested the implementation successfully on Windows-10 with MINGW (RubyInstaller), Ubuntu-18.04 with glibc, Alpine-Linux-3.7 with musl-libc and Android-7.0 with bionic-libc (termux).

The conversion is done by a fast path and as a fallback by a slower path. The slow path is used under these conditions:
* `timegm()` is not available (on Windows)
* `RUBY_VERSION < 2.3.0` (it doesn't provide `rb_time_timespec_new()`)
* time conversion by `timegm()` or `mktime()` fails at runtime (happens on Android)

I did some very simple benchmarks with the following results:

```
ruby -Ilib -rpg -e "map=PG::TypeMapByColumn.new([PG::TextDecoder::TimestampWithTimeZone.new]); res=PG.connect.exec(\"SELECT '2016-01-02 22:23:59.3-04'::timestamptz\").map_types!(map); st=Time.now; 10000.times{ res.getvalue(0,0) }; p Time.now-st"
```

version|time
-------|-----
master (RegExp)|0.71s
vhl-time-decoder slow path|0.41s
vhl-time-decoder fast path|0.022s
