### PR TITLE
Add a numeric decoder written in C

### DIFF
--- a/ext/pg_text_decoder.c
+++ b/ext/pg_text_decoder.c
@@ -41,6 +41,7 @@ VALUE rb_mPG_TextDecoder;
 static ID s_id_decode;
 static ID s_id_Rational;
 static ID s_id_new;
+static ID s_id_BigDecimal;
 
 /*
  * Document-class: PG::TextDecoder::Boolean < PG::SimpleDecoder
@@ -136,6 +137,19 @@ pg_text_dec_integer(t_pg_coder *conv, char *val, int len, int tuple, int field, 
 	}
 	/* Fallback to ruby method if number too big or unrecognized. */
 	return rb_cstr2inum(val, 10);
+}
+
+/*
+ * Document-class: PG::TextDecoder::Numeric < PG::SimpleDecoder
+ *
+ * This is a decoder class for conversion of PostgreSQL numeric types
+ * to Ruby BigDecimal objects.
+ *
+ */
+static VALUE
+pg_text_dec_numeric(t_pg_coder *conv, char *val, int len, int tuple, int field, int enc_idx)
+{
+	return rb_funcall(rb_cObject, s_id_BigDecimal, 1, rb_str_new(val, len));
 }
 
 /*
@@ -733,6 +747,9 @@ init_pg_text_decoder()
 	s_id_Rational = rb_intern("Rational");
 	s_id_new = rb_intern("new");
 
+	rb_require("bigdecimal");
+	s_id_BigDecimal = rb_intern("BigDecimal");
+
 	/* This module encapsulates all decoder classes with text input format */
 	rb_mPG_TextDecoder = rb_define_module_under( rb_mPG, "TextDecoder" );
 
@@ -743,6 +760,8 @@ init_pg_text_decoder()
 	pg_define_coder( "Integer", pg_text_dec_integer, rb_cPG_SimpleDecoder, rb_mPG_TextDecoder );
 	/* dummy = rb_define_class_under( rb_mPG_TextDecoder, "Float", rb_cPG_SimpleDecoder ); */
 	pg_define_coder( "Float", pg_text_dec_float, rb_cPG_SimpleDecoder, rb_mPG_TextDecoder );
+	/* dummy = rb_define_class_under( rb_mPG_TextDecoder, "BigDecimal", rb_cPG_SimpleDecoder ); */
+	pg_define_coder( "Numeric", pg_text_dec_numeric, rb_cPG_SimpleDecoder, rb_mPG_TextDecoder );
 	/* dummy = rb_define_class_under( rb_mPG_TextDecoder, "String", rb_cPG_SimpleDecoder ); */
 	pg_define_coder( "String", pg_text_dec_string, rb_cPG_SimpleDecoder, rb_mPG_TextDecoder );
 	/* dummy = rb_define_class_under( rb_mPG_TextDecoder, "Bytea", rb_cPG_SimpleDecoder ); */

--- a/lib/pg/basic_type_mapping.rb
+++ b/lib/pg/basic_type_mapping.rb
@@ -175,7 +175,7 @@ module PG::BasicTypeRegistry
 	alias_type    0, 'int8', 'int2'
 	alias_type    0, 'oid',  'int2'
 
-	# register_type 0, 'numeric', OID::Decimal.new
+	register_type 0, 'numeric', PG::TextEncoder::Numeric, PG::TextDecoder::Numeric
 	register_type 0, 'text', PG::TextEncoder::String, PG::TextDecoder::String
 	alias_type 0, 'varchar', 'text'
 	alias_type 0, 'char', 'text'
@@ -433,6 +433,7 @@ class PG::BasicTypeMapForQueries < PG::TypeMapByClass
 		# to unnecessary type conversions on server side.
 		Integer => [0, 'int8'],
 		Float => [0, 'float8'],
+		BigDecimal => [0, 'numeric'],
 		Array => :get_array_type,
 	}
 

--- a/lib/pg/text_encoder.rb
+++ b/lib/pg/text_encoder.rb
@@ -25,6 +25,12 @@ module PG
 			end
 		end
 
+		class Numeric < SimpleEncoder
+			def encode(value)
+				value.is_a?(BigDecimal) ? value.to_s('F') : value
+			end
+		end
+
 		class JSON < SimpleEncoder
 			def encode(value)
 				::JSON.generate(value, quirks_mode: true)

--- a/spec/pg/basic_type_mapping_spec.rb
+++ b/spec/pg/basic_type_mapping_spec.rb
@@ -42,6 +42,19 @@ describe 'Basic type mapping' do
 
 			expect( result_typenames(res) ).to eq( ['bigint[]', 'bigint[]', 'double precision[]', 'text[]'] )
 		end
+
+		it "should do bigdecimal param encoding" do
+			large = ('123456790'*10) << '.' << ('012345679')
+			res = @conn.exec_params( "SELECT $1::numeric,$2::numeric",
+				[BigDecimal.new('1'), BigDecimal.new(large)], nil, basic_type_mapping )
+
+			expect( res.values ).to eq( [
+					[ "1.0", large ],
+			] )
+
+			expect( result_typenames(res) ).to eq( ['numeric', 'numeric'] )
+		end
+
 	end
 
 
@@ -163,6 +176,27 @@ describe 'Basic type mapping' do
 					expect( res.getvalue(0,1) ).to eq( Date.new(1913, 12, 31) )
 					expect( res.getvalue(0,2) ).to eq( 'infinity' )
 					expect( res.getvalue(0,3) ).to eq( '-infinity' )
+				end
+			end
+
+			it "should do numeric type conversions" do
+				[0].each do |format|
+				  small = '123456790123.12'
+					large = ('123456790'*10) << '.' << ('012345679')
+					numerics = [
+						'1',
+						'1.0',
+						'1.2',
+						small,
+						large,
+					]
+					sql_numerics = numerics.map { |v| "CAST(#{v} AS numeric)" }
+					res = @conn.exec_params( "SELECT #{sql_numerics.join(',')}", [], format )
+					expect( res.getvalue(0,0) ).to eq( BigDecimal('1') )
+					expect( res.getvalue(0,1) ).to eq( BigDecimal('1') )
+					expect( res.getvalue(0,2) ).to eq( BigDecimal('1.2') )
+					expect( res.getvalue(0,3) ).to eq( BigDecimal(small) )
+					expect( res.getvalue(0,4) ).to eq( BigDecimal(large) )
 				end
 			end
 


### PR DESCRIPTION
This is about 10% faster than a pure-ruby decoder.

Passing an Integer to BigDecimal is not significantly different than
passing a String, and passing a Flonum is actually slower. Integers
probably aren't faster because BigDecimal converts them to cstrs
internally:

https://github.com/ruby/ruby/blob/trunk/ext/bigdecimal/bigdecimal.c#L290-L292
https://github.com/ruby/ruby/blob/trunk/ext/bigdecimal/bigdecimal.c#L302-L306

Flonums are slower because BigDecimal converts them to Rational
and then does some processing on the Rational:

https://github.com/ruby/ruby/blob/trunk/ext/bigdecimal/bigdecimal.c#L247-L278

Here's the code I originally had that tested Integer and Flonum
approaches (I removed it when I benchmarked and found those approachs
were the same speed or slower):

```
	VALUE bd;
	char *found;
	if ((found = strchr(val, '.'))) {
		if (len <= 16) {
			bd = DBL2NUM(rb_cstr_to_dbl(val, 1));
			len -= found - val - 1;
			return rb_funcall(rb_cObject, s_id_BigDecimal, 2, bd, INT2NUM(len));
		}
		bd = rb_str_new(val, len);
	} else {
		bd = pg_text_dec_integer(conv, val, len, tuple, field, enc_idx);
	}

	return rb_funcall(rb_cObject, s_id_BigDecimal, 1, bd);
```

This also includes a text encoder written in ruby.

Example test/benchmark code:

```ruby
require 'pg'
require 'bigdecimal'
require 'benchmark/ips'

int_max = 10**18
small_float_range = 0...15
large_float_range = 0...1000

log_cols = ((ENV['BENCH_LOG_COLS'] || 6).to_i)
log_rows = ((ENV['BENCH_LOG_ROWS'] || 6).to_i)
cols = 2**log_cols

raise "BENCH_LOG_COLS must be <= 10" if log_cols > 10
raise "BENCH_LOG_ROWS must be <= 10" if log_rows > 10

if ENV['PURE_RUBY'] == '1'
  class NumericDecoder < PG::SimpleDecoder
    def decode(string, tuple=nil, field=nil)
      BigDecimal(string)
    end
  end
  class NumericEncoder < PG::SimpleEncoder
    def encode(decimal)
      decimal.to_s('F')
    end
  end
  PG::BasicTypeRegistry.register_type(0, 'numeric', NumericEncoder, NumericDecoder)
end

conn = PG.connect
unless ENV['ALL_STRINGS'] == '1'
  conn.type_map_for_queries = PG::BasicTypeMapForQueries.new conn
  conn.type_map_for_results = PG::BasicTypeMapForResults.new conn
end

conn.exec("BEGIN")
at_exit{conn.exec("ROLLBACK")}
conn.exec("CREATE TABLE int_numeric_test (#{(0...cols).map{|i| "d#{i} numeric(40, 2) DEFAULT '#{(rand*int_max).to_i}'"}.join(', ')})")
conn.exec("CREATE TABLE small_float_numeric_test (#{(0...cols).map{|i| "d#{i} numeric(15, 2) DEFAULT '#{s = small_float_range.map{rand(10)}.join; s[-3] = '.'; s}'"}.join(', ')})")
conn.exec("CREATE TABLE large_float_numeric_test (#{(0...cols).map{|i| "d#{i} numeric(1000, 10) DEFAULT '#{s = large_float_range.map{rand(10)}.join; s[-10] = '.'; s}'"}.join(', ')})")

conn.exec("INSERT INTO int_numeric_test DEFAULT VALUES")
conn.exec("INSERT INTO small_float_numeric_test DEFAULT VALUES")
conn.exec("INSERT INTO large_float_numeric_test DEFAULT VALUES")
log_rows.times do
  conn.exec("INSERT INTO int_numeric_test SELECT * FROM int_numeric_test")
  conn.exec("INSERT INTO small_float_numeric_test SELECT * FROM small_float_numeric_test")
  conn.exec("INSERT INTO large_float_numeric_test SELECT * FROM large_float_numeric_test")
end

['int_numeric_test', 'small_float_numeric_test', 'large_float_numeric_test'].each do |v|
  conn.exec( "SELECT d0 FROM #{v} LIMIT 1" ) do |res|
    v = res.getvalue(0, 0)
    print "Example #{v} value: #{v.is_a?(BigDecimal) ? v.to_s('F') : v}\n"
  end
end
puts

small = '123456790123.12'
large = ('123456790'*10) << '.' << ('012345679')
puts "Basic Tests"
numeric_tests = [
  '1',
  '1.0',
  '1.2',
  small,
  large,
]
numeric_tests.each do |d|
  conn.exec("SELECT #{d}::numeric") do |res|
    v = res.getvalue(0, 0)
    print "Test decimal value: #{d} should equal #{v.is_a?(BigDecimal) ? v.to_s('F') : v}\n"
  end
end

conn.exec_params("SELECT $1::numeric, $2::numeric", [BigDecimal(1), BigDecimal(large)]) do |res|
  v = res.getvalue(0, 0)
  print "Test bigdecimal text encoder values: 1 should equal #{v.is_a?(BigDecimal) ? v.to_s('F') : v}\n"
  v = res.getvalue(0, 1)
  print "Test bigdecimal text encoder values: #{large} should equal #{v.is_a?(BigDecimal) ? v.to_s('F') : v}\n"
end

Benchmark.ips do |x|
  x.warmup = -1
  ['int_numeric_test', 'small_float_numeric_test', 'large_float_numeric_test'].each do |v|
    sql = "SELECT * FROM #{v}"
    x.report(v) do
      conn.exec(sql) do |res|
        ntuples = res.ntuples
        recnum = 0
        while recnum < ntuples
          converted_rec = {}
          fieldnum = 0
          while fieldnum < cols
            res.getvalue(recnum, fieldnum)
            fieldnum += 1
          end
          recnum += 1
        end
      end
    end
  end
end

=begin
Integer Numeric
Strings: ~275 ips
Pure Ruby BigDecimal: ~110 ips
C BigDecimal: ~120 ips

Small Float Numeric
Strings: ~300 ips
Pure Ruby BigDecimal: ~115 ips
C BigDecimal: ~126 ips

Large Float Numeric
Strings: ~10 ips
Pure Ruby BigDecimal: ~7.3 ips
C BigDecimal: ~7.3 ips
=end
```