### PR TITLE
WIP: handle UTC times correctly in decoder

### DIFF
--- a/ext/pg_text_decoder.c
+++ b/ext/pg_text_decoder.c
@@ -695,7 +695,7 @@ static VALUE pg_text_decoder_timestamp_do(t_pg_coder *conv, char *val, int len, 
 					}
 					break;
 				}
-				case 1: /* interprete as local time, return as local time */
+				case 1: /* interpret as local time, return as local time */
 					/* Fall through to rb_funcall(), because I couldn't find a fast way to
 					 * use rb_time_timespec_new() for this case.
 					 */

--- a/lib/pg/basic_type_mapping.rb
+++ b/lib/pg/basic_type_mapping.rb
@@ -199,7 +199,10 @@ module PG::BasicTypeRegistry
 	register_type 0, 'float4', PG::TextEncoder::Float, PG::TextDecoder::Float
 	alias_type 0, 'float8', 'float4'
 
-	register_type 0, 'timestamp', PG::TextEncoder::TimestampWithoutTimeZone, PG::TextDecoder::TimestampWithoutTimeZone
+	# Default is to assume UTC times are stored in timestampwithoutzone, optionally we could register
+	# a typemapper that strips out timezone (without a UTC conversion)
+	# register_type 0, 'timestamp', PG::TextEncoder::TimestampWithoutTimeZone, PG::TextDecoder::TimestampWithoutTimeZone
+	register_type 0, 'timestamp', PG::TextEncoder::TimestampUtc, PG::TextDecoder::TimestampUtc
 	register_type 0, 'timestamptz', PG::TextEncoder::TimestampWithTimeZone, PG::TextDecoder::TimestampWithTimeZone
 	register_type 0, 'date', PG::TextEncoder::Date, PG::TextDecoder::Date
 	# register_type 'time', OID::Time.new

--- a/spec/pg/basic_type_mapping_spec.rb
+++ b/spec/pg/basic_type_mapping_spec.rb
@@ -153,12 +153,12 @@ describe 'Basic type mapping' do
 
 			it "should do datetime without time zone type conversions" do
 				[0].each do |format|
-					res = @conn.exec_params( "SELECT CAST('2013-12-31 23:58:59+02' AS TIMESTAMP WITHOUT TIME ZONE),
-																		CAST('1913-12-31 23:58:59.123-03' AS TIMESTAMP WITHOUT TIME ZONE),
+					res = @conn.exec_params( "SELECT CAST('2013-12-31 23:58:59+0' AS TIMESTAMP WITHOUT TIME ZONE),
+																		CAST(('1913-12-31 23:58:59.123 -03:00'::TIMESTAMP WITH TIME ZONE AT TIME ZONE 'UTC') AS TIMESTAMP WITHOUT TIME ZONE),
 																		CAST('infinity' AS TIMESTAMP WITHOUT TIME ZONE),
 																		CAST('-infinity' AS TIMESTAMP WITHOUT TIME ZONE)", [], format )
-					expect( res.getvalue(0,0) ).to eq( Time.new(2013, 12, 31, 23, 58, 59) )
-					expect( res.getvalue(0,1) ).to be_within(1e-3).of(Time.new(1913, 12, 31, 23, 58, 59.123))
+					expect( res.getvalue(0,0) ).to eq( Time.new(2013, 12, 31, 23, 58, 59, "+00:00") )
+					expect( res.getvalue(0,1) ).to be_within(1e-3).of(Time.new(1913, 12, 31, 23, 58, 59.123, "-03:00"))
 					expect( res.getvalue(0,2) ).to eq( 'infinity' )
 					expect( res.getvalue(0,3) ).to eq( '-infinity' )
 				end


### PR DESCRIPTION
This still fails specs, but something is not right with handling of timestamp without time zone, stuff is being treated as local time incorrectly. 

I think it may make sense to add a complete integration test here, where we insert into a temp table and then select out of it to avoid needing to do very fancy casting (like in the PR) in tests