### PR TITLE
Fix various issues in the inet/cidr decoder

### DIFF
--- a/ext/pg_text_decoder.c
+++ b/ext/pg_text_decoder.c
@@ -827,18 +827,29 @@ pg_text_dec_inet(t_pg_coder *conv, char *val, int len, int tuple, int field, int
 	VALUE ip_int;
 	VALUE vmasks;
 	char dst[16];
+	char buf[64];
 	int af = strchr(val, '.') ? AF_INET : AF_INET6;
 	int mask = -1;
+
+	if (len >= 64) {
+		rb_raise(rb_eTypeError, "too long data for text inet converter in tuple %d field %d", tuple, field);
+	}
 
 	if (len >= 4) {
 		if (val[len-2] == '/') {
 			mask = val[len-1] - '0';
+			memcpy(buf, val, len-2);
+			val = buf;
 			val[len-2] = '\0';
 		} else if (val[len-3] == '/') {
-			mask = (val[len-2]- '0') *10 + val[len-1] - '0';
+			mask = (val[len-2]- '0')*10 + val[len-1] - '0';
+			memcpy(buf, val, len-3);
+			val = buf;
 			val[len-3] = '\0';
 		} else if (val[len-4] == '/') {
 			mask = (val[len-3]- '0')*100 + (val[len-2]- '0')*10 + val[len-1] - '0';
+			memcpy(buf, val, len-4);
+			val = buf;
 			val[len-4] = '\0';
 		}
 	}
@@ -848,6 +859,8 @@ pg_text_dec_inet(t_pg_coder *conv, char *val, int len, int tuple, int field, int
 	}
 
 	if (af == AF_INET) {
+		unsigned int ip_int_native;
+
 		if (mask == -1) {
 			mask = 32;
 		} else if (mask < 0 || mask > 32) {
@@ -855,9 +868,27 @@ pg_text_dec_inet(t_pg_coder *conv, char *val, int len, int tuple, int field, int
 		}
 		vmasks = s_vmasks4;
 
-		ip_int = UINT2NUM(read_nbo32(dst));
+		ip_int_native = read_nbo32(dst);
+
+		/* Work around broken IPAddr behavior of convering portion
+		   of address after netmask to 0 */
+		switch (mask) {
+			case 0:
+				ip_int_native = 0;
+				break;
+			case 32:
+				/* nothing to do */
+				break;
+			default:
+				ip_int_native &= ~((1UL<<(32-mask))-1);
+				break;
+		}
+
+		ip_int = UINT2NUM(ip_int_native);
 	} else {
 		unsigned long long * dstllp = (unsigned long long *)dst;
+		unsigned long long ip_int_native1;
+		unsigned long long ip_int_native2;
 
 		if (mask == -1) {
 			mask = 128;
@@ -866,11 +897,28 @@ pg_text_dec_inet(t_pg_coder *conv, char *val, int len, int tuple, int field, int
 		}
 		vmasks = s_vmasks6;
 
-		/* 4 Bignum allocations */
-		ip_int = ULL2NUM(read_nbo64(dstllp));
-		ip_int = rb_funcall(ip_int, s_id_lshift, 1, INT2NUM(64));
+		ip_int_native1 = read_nbo64(dstllp);
 		dstllp++;
-		ip_int = rb_funcall(ip_int, s_id_add, 1, ULL2NUM(read_nbo64(dstllp)));
+		ip_int_native2 = read_nbo64(dstllp);
+
+		if (mask == 128) {
+			/* nothing to do */
+		} else if (mask == 64) {
+			ip_int_native2 = 0;
+		} else if (mask == 0) {
+			ip_int_native1 = 0;
+			ip_int_native2 = 0;
+		} else if (mask < 64) {
+			ip_int_native1 &= ~((1ULL<<(64-mask))-1);
+			ip_int_native2 = 0;
+		} else {
+			ip_int_native2 &= ~((1ULL<<(128-mask))-1);
+		}
+
+		/* 4 Bignum allocations */
+		ip_int = ULL2NUM(ip_int_native1);
+		ip_int = rb_funcall(ip_int, s_id_lshift, 1, INT2NUM(64));
+		ip_int = rb_funcall(ip_int, s_id_add, 1, ULL2NUM(ip_int_native2));
 	}
 
 	if (use_ipaddr_alloc) {
@@ -895,6 +943,7 @@ init_pg_text_decoder()
 {
 	rb_require("ipaddr");
 	s_IPAddr = rb_funcall(rb_cObject, rb_intern("const_get"), 1, rb_str_new2("IPAddr"));
+	rb_global_variable(&s_IPAddr);
 	s_ivar_family = rb_intern("@family");
 	s_ivar_addr = rb_intern("@addr");
 	s_ivar_mask_addr = rb_intern("@mask_addr");

--- a/spec/pg/basic_type_mapping_spec.rb
+++ b/spec/pg/basic_type_mapping_spec.rb
@@ -256,11 +256,12 @@ describe 'Basic type mapping' do
 			it "should do inet type conversions" do
 				[0].each do |format|
 					vals = [
-					  '1.2.3.4',
+						'1.2.3.4',
 						'0.0.0.0/0',
 						'1.0.0.0/8',
 						'1.2.0.0/16',
 						'1.2.3.0/24',
+						'1.2.3.4/24',
 						'1.2.3.4/32',
 						'1.2.3.128/25',
 						'1234:3456:5678:789a:9abc:bced:edf0:f012',
@@ -269,27 +270,16 @@ describe 'Basic type mapping' do
 						'1234:3456:5678:789a::/64',
 						'1234:3456:5678:789a:9abc:bced::/96',
 						'1234:3456:5678:789a:9abc:bced:edf0:f012/128',
+						'1234:3456:5678:789a:9abc:bced:edf0:f012/0',
+						'1234:3456:5678:789a:9abc:bced:edf0:f012/32',
+						'1234:3456:5678:789a:9abc:bced:edf0:f012/64',
+						'1234:3456:5678:789a:9abc:bced:edf0:f012/96',
 					]
-					sql_vals = vals.map { |v| "CAST('#{v}' AS inet)" }
+					sql_vals = vals.map{|v| "CAST('#{v}' AS inet)"}
 					res = @conn.exec_params(("SELECT " + sql_vals.join(', ')), [], format )
 					vals.each_with_index do |v, i|
 						val = res.getvalue(0,i)
-						ip, prefix = v.split('/', 2)
-						expect( val.to_s ).to eq( ip )
-						if val.respond_to?(:prefix)
-							val_prefix = val.prefix
-						else
-					    default_prefix = (val.family == Socket::AF_INET ? 32 : 128)
-							range = val.to_range
-							val_prefix	= default_prefix - Math.log(((range.end.to_i - range.begin.to_i) + 1), 2).to_i
-						end
-						if v.include?('/')
-							expect( val_prefix ).to eq( prefix.to_i )
-						elsif v.include?('.')
-							expect( val_prefix ).to eq( 32 )
-						else
-							expect( val_prefix ).to eq( 128 )
-						end
+						expect( res.getvalue(0,i) ).to eq( IPAddr.new(v) )
 					end
 				end
 			end


### PR DESCRIPTION
I found these issues by porting the code to sequel_pg and running
Sequel's tests.

It turns out that IPAddr doesn't support non-zero parts after the
netmask, such as 1.2.3.4/24, and automatically modifies the part
after the netmask to be 0 (turning 1.2.3.4/24 to 1.2.3.0/24).
Because the default is to set instance variables for performance,
this resulted in the creation of IPAddr instances that you could
not generate using IPAddr's public API.  To fix that, mask the
part of the IP address integer(s) before calling UINT2NUM or
ULL2NUM.

I've modified the inet tests to be much simpler, just checking
that the returned value for the inet column matches what you
would get if you parsed the input string with IPAddr.new. I've
also added tests for the above issue.

Modifying the passed in char* buffer is a bad idea, as that
modifies the underlying PG::Result storage directly, leading to
multiple calls to getvalue returning different data.  Instead,
copy the input string to a stack buffer work off of that if
there is a netmask.  This uses a buffer size of 64, but I think
the maximum for IPv6 is only 40 if you count the trailing string
terminator.

This also calls rb_global_variable for s_IPAddr so that you don't
get undefined behavior if the IPAddr constant is garbage collected.