### PR TITLE
Use rb_enc_alias

### DIFF
--- a/ext/pg.c
+++ b/ext/pg.c
@@ -143,7 +143,7 @@ pg_find_or_create_johab(void)
 
 	enc_index = rb_define_dummy_encoding(aliases[0]);
 	for (i = 1; i < sizeof(aliases)/sizeof(aliases[0]); ++i) {
-		rb_encdb_alias(aliases[i], aliases[0]);
+		rb_enc_alias(aliases[i], aliases[0]);
 	}
 	return rb_enc_from_index(enc_index);
 }

--- a/ext/pg.h
+++ b/ext/pg.h
@@ -22,7 +22,7 @@
 #include "ruby/encoding.h"
 
 /* exported by ruby-1.9.3+ but not declared */
-extern int rb_encdb_alias(const char *, const char *);
+extern int rb_enc_alias(const char *, const char *);
 
 #define PG_ENCODING_SET_NOCHECK(obj,i) \
 	do { \


### PR DESCRIPTION
`rb_encdb`-prefixed functions are only for internal use.
use `rb_enc_alias` instead.