### PR TITLE
Ignore timeshift for BC timestamp.

### DIFF
--- a/spec/pg/basic_type_mapping_spec.rb
+++ b/spec/pg/basic_type_mapping_spec.rb
@@ -258,7 +258,7 @@ describe 'Basic type mapping' do
 																		CAST('-infinity' AS TIMESTAMP WITH TIME ZONE)", [], format )
 					expect( res.getvalue(0,0).iso8601(3) ).to eq( Time.new(2013, 12, 31, 23, 58, 59, "+02:00").getlocal.iso8601(3) )
 					expect( res.getvalue(0,1).iso8601(3) ).to eq( Time.new(1913, 12, 31, 23, 58, 59.1231, "-03:00").getlocal.iso8601(3) )
-					expect( res.getvalue(0,2).iso8601(3) ).to eq( Time.new(-4713, 11, 24, 23, 58, 59.1231, "-03:00").getlocal.iso8601(3) )
+					expect( res.getvalue(0,2) ).to be_within(1e-3).of( Time.new(-4713, 11, 24, 23, 58, 59.1231, "-03:00").getlocal )
 					expect( res.getvalue(0,3).iso8601(3) ).to eq( Time.new(294276, 12, 31, 23, 58, 59.1231, "+03:00").getlocal.iso8601(3) )
 					expect( res.getvalue(0,4) ).to eq( 'infinity' )
 					expect( res.getvalue(0,5) ).to eq( '-infinity' )

--- a/spec/pg/basic_type_mapping_spec.rb
+++ b/spec/pg/basic_type_mapping_spec.rb
@@ -256,10 +256,10 @@ describe 'Basic type mapping' do
 																		CAST('294276-12-31 23:58:59.1231+03' AS TIMESTAMP WITH TIME ZONE),
 																		CAST('infinity' AS TIMESTAMP WITH TIME ZONE),
 																		CAST('-infinity' AS TIMESTAMP WITH TIME ZONE)", [], format )
-					expect( res.getvalue(0,0).iso8601(3) ).to eq( Time.new(2013, 12, 31, 23, 58, 59, "+02:00").getlocal.iso8601(3) )
-					expect( res.getvalue(0,1).iso8601(3) ).to eq( Time.new(1913, 12, 31, 23, 58, 59.1231, "-03:00").getlocal.iso8601(3) )
+					expect( res.getvalue(0,0) ).to be_within(1e-3).of( Time.new(2013, 12, 31, 23, 58, 59, "+02:00").getlocal )
+					expect( res.getvalue(0,1) ).to be_within(1e-3).of( Time.new(1913, 12, 31, 23, 58, 59.1231, "-03:00").getlocal )
 					expect( res.getvalue(0,2) ).to be_within(1e-3).of( Time.new(-4713, 11, 24, 23, 58, 59.1231, "-03:00").getlocal )
-					expect( res.getvalue(0,3).iso8601(3) ).to eq( Time.new(294276, 12, 31, 23, 58, 59.1231, "+03:00").getlocal.iso8601(3) )
+					expect( res.getvalue(0,3) ).to be_within(1e-3).of( Time.new(294276, 12, 31, 23, 58, 59.1231, "+03:00").getlocal )
 					expect( res.getvalue(0,4) ).to eq( 'infinity' )
 					expect( res.getvalue(0,5) ).to eq( '-infinity' )
 				end

--- a/spec/pg/type_spec.rb
+++ b/spec/pg/type_spec.rb
@@ -123,6 +123,12 @@ describe "PG::Type derivations" do
 						to eq( Time.new(2016,1,2, 23,23,59.123456, "-04:00").iso8601(5) )
 					expect( textdec_timestamptz.decode('2016-08-02 23:23:59.123456+10').iso8601(5) ).
 						to eq( Time.new(2016,8,2, 23,23,59.123456, "+10:00").iso8601(5) )
+					expect( textdec_timestamptz.decode('1913-12-31 23:58:59.1231-03').iso8601(5) ).
+						to eq( Time.new(1913, 12, 31, 23, 58, 59.1231, "-03:00").iso8601(5) )
+					expect( textdec_timestamptz.decode('4714-11-24 23:58:59.1231-03 BC').iso8601(5) ).
+						to eq( Time.new(-4713, 11, 24, 23, 58, 59.1231, "-03:00").iso8601(5) )
+					expect( textdec_timestamptz.decode('294276-12-31 23:58:59.1231+03').iso8601(5) ).
+						to eq( Time.new(294276, 12, 31, 23, 58, 59.1231, "+03:00").iso8601(5) )
 				end
 				it 'decodes timestamps with hour:minute timezone' do
 					expect( textdec_timestamptz.decode('2015-01-26 17:26:42.691511-04:15') ).


### PR DESCRIPTION
Ruby and PostgreSQL seem to have a different opinion about the right timezone to be applied to BC dates in some countries. Therefore verify the timestamp without timezone.
This failed for @ged like so:

1) Basic type mapping PG::BasicTypeMapForResults connection wide type mapping should convert format 0 timestamps with time zone
Failure/Error: expect( res.getvalue(0,2).iso8601(3) ).to eq( Time.new(-4713, 11, 24, 23, 58, 59.1231, "-03:00").getlocal.iso8601(3) )

   expected: "-4713-11-24T18:58:59.123-08:00"
        got: "-4713-11-24T19:06:01.123-07:52"

   (compared using ==)
: # ./spec/pg/basic_type_mapping_spec.rb:261:in `block (5 levels) in <top (required)>'
: # ./spec/helpers.rb:29:in `block in included'