### PR TITLE
Add feature to set testing port.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,8 @@ before_install:
         sudo ./postgresql-$PGVERSION.run --extract-only 1 --mode unattended
     fi
 script: |
+  # Set random port.
+  export PGPORT=14321
   if [ -z "$PGCROSS" ]; then
     rake compile test
   else

--- a/spec/helpers.rb
+++ b/spec/helpers.rb
@@ -198,8 +198,8 @@ module PG::TestingHelpers
 		@test_pgdata = TEST_DIRECTORY + 'data'
 		@test_pgdata.mkpath
 
-		@port = 54321
-		ENV['PGPORT'] = @port.to_s
+		ENV['PGPORT'] ||= "54321"
+		@port = ENV['PGPORT'].to_i
 		ENV['PGHOST'] = 'localhost'
 		@conninfo = "host=localhost port=#{@port} dbname=test"
 

--- a/spec/pg/connection_spec.rb
+++ b/spec/pg/connection_spec.rb
@@ -279,7 +279,7 @@ describe PG::Connection do
 		expect( @conn.db ).to eq( "test" )
 		expect( @conn.user ).to be_a_kind_of( String )
 		expect( @conn.pass ).to eq( "" )
-		expect( @conn.port ).to eq( 54321 )
+		expect( @conn.port ).to eq( @port )
 		expect( @conn.tty ).to eq( "" )
 		expect( @conn.options ).to eq( "" )
 	end
@@ -765,7 +765,7 @@ describe PG::Connection do
 	it "can return the default connection options as a Hash" do
 		expect( described_class.conndefaults_hash ).to be_a( Hash )
 		expect( described_class.conndefaults_hash ).to include( :user, :password, :dbname, :host, :port )
-		expect( ['5432', '54321'] ).to include( described_class.conndefaults_hash[:port] )
+		expect( ['5432', '54321', @port.to_s] ).to include( described_class.conndefaults_hash[:port] )
 		expect( @conn.conndefaults_hash ).to eq( described_class.conndefaults_hash )
 	end
 


### PR DESCRIPTION
Hello,
I want to add a feature to set testing port, because in my environment (Fedora project's build environment), I can not use the standard port.

Ref: https://bitbucket.org/ged/ruby-pg/issues/283
