### PR TITLE
Suppress "warning: URI.regexp is obsolete".

### DIFF
--- a/lib/pg/connection.rb
+++ b/lib/pg/connection.rb
@@ -47,7 +47,7 @@ class PG::Connection
 
 		if args.length == 1
 			case args.first
-			when URI, /\A#{URI.regexp}\z/
+			when URI, /\A#{URI::ABS_URI_REF}\z/
 				uri = URI(args.first)
 				options.merge!( Hash[URI.decode_www_form( uri.query )] ) if uri.query
 			when /=/


### PR DESCRIPTION
Maybe this PR fixes below issue.
https://bitbucket.org/ged/ruby-pg/issues/286/warning-uriregexp-is-obsolete

As a default behavior of the testing command, there are messages for the stdout and stderr like this.
This situation makes us harder to find a real warning issue like this issue.

I think we can suppress the outputted message as much as possible except "..." by RSpec as a default behavior of `rake test`.
The messages could be outputted to `tmp_test_specs/setup.log` or only `$VERBOSE` mode.

```
$ bundle exec rake test
...
Setting up test database for Basic type mapping
Creating the test DB
Warning: no type cast defined for type "name" with oid 19. Please cast this type explicitly to TEXT to be safe for future changes.
Warning: no type cast defined for type "regproc" with oid 24. Please cast this type explicitly to TEXT to be safe for future changes.
Tearing down test database
No pidfile (#<Pathname:/home/jaruga/git/ruby-pg/tmp_test_specs/data/postmaster.pid>)
Setting up test database for PG::TypeMapByOid
Creating the test DB
...
```

Below kind of warning message to output message to stderr could be tested like below method on RSpec 3.
https://github.com/ged/ruby-pg/blob/master/lib/pg/basic_type_mapping.rb#L304-L305

```
expect { my_method }.to output("my message").to_stdout
expect { my_method }.to output("my error").to_stderr
```

Ref: https://stackoverflow.com/questions/16507067/testing-stdout-output-in-rspec
