### PR TITLE
Add a test to check a content of the warning.

### DIFF
--- a/lib/pg/basic_type_mapping.rb
+++ b/lib/pg/basic_type_mapping.rb
@@ -301,7 +301,7 @@ class PG::BasicTypeMapForResults < PG::TypeMapByOid
 			format = result.fformat(field)
 			oid = result.ftype(field)
 			unless @already_warned[format][oid]
-				STDERR.puts "Warning: no type cast defined for type #{@typenames_by_oid[format][oid].inspect} with oid #{oid}. Please cast this type explicitly to TEXT to be safe for future changes."
+				$stderr.puts "Warning: no type cast defined for type #{@typenames_by_oid[format][oid].inspect} with oid #{oid}. Please cast this type explicitly to TEXT to be safe for future changes."
 				 @already_warned[format][oid] = true
 			end
 			super

--- a/spec/pg/basic_type_mapping_spec.rb
+++ b/spec/pg/basic_type_mapping_spec.rb
@@ -21,6 +21,14 @@ ensure
 	end
 end
 
+def expect_to_typecase_result_value_warning
+	warning = 'Warning: no type cast defined for type "name" with oid 19. '\
+		"Please cast this type explicitly to TEXT to be safe for future changes.\n"\
+		'Warning: no type cast defined for type "regproc" with oid 24. '\
+		"Please cast this type explicitly to TEXT to be safe for future changes.\n"
+	expect { yield }.to output(warning).to_stderr
+end
+
 describe 'Basic type mapping' do
 
 	describe PG::BasicTypeMapForQueries do
@@ -187,7 +195,9 @@ describe 'Basic type mapping' do
 				it "should convert format #{format} timestamps per TimestampUtc" do
 					restore_type("timestamp") do
 						PG::BasicTypeRegistry.register_type 0, 'timestamp', nil, PG::TextDecoder::TimestampUtc
-						@conn.type_map_for_results = PG::BasicTypeMapForResults.new(@conn)
+						expect_to_typecase_result_value_warning do
+							@conn.type_map_for_results = PG::BasicTypeMapForResults.new(@conn)
+						end
 						res = @conn.exec_params( "SELECT CAST('2013-07-31 23:58:59+02' AS TIMESTAMP WITHOUT TIME ZONE),
 																			CAST('1913-12-31 23:58:59.1231-03' AS TIMESTAMP WITHOUT TIME ZONE),
 																			CAST('4714-11-24 23:58:59.1231-03 BC' AS TIMESTAMP WITHOUT TIME ZONE),
@@ -209,7 +219,9 @@ describe 'Basic type mapping' do
 					restore_type("timestamp") do
 						PG::BasicTypeRegistry.register_type 0, 'timestamp', nil, PG::TextDecoder::TimestampUtcToLocal
 						PG::BasicTypeRegistry.register_type 1, 'timestamp', nil, PG::BinaryDecoder::TimestampUtcToLocal
-						@conn.type_map_for_results = PG::BasicTypeMapForResults.new(@conn)
+						expect_to_typecase_result_value_warning do
+							@conn.type_map_for_results = PG::BasicTypeMapForResults.new(@conn)
+						end
 						res = @conn.exec_params( "SELECT CAST('2013-07-31 23:58:59+02' AS TIMESTAMP WITHOUT TIME ZONE),
 																			CAST('1913-12-31 23:58:59.1231-03' AS TIMESTAMP WITHOUT TIME ZONE),
 																			CAST('4714-11-24 23:58:59.1231-03 BC' AS TIMESTAMP WITHOUT TIME ZONE),
@@ -231,7 +243,9 @@ describe 'Basic type mapping' do
 					restore_type("timestamp") do
 						PG::BasicTypeRegistry.register_type 0, 'timestamp', nil, PG::TextDecoder::TimestampLocal
 						PG::BasicTypeRegistry.register_type 1, 'timestamp', nil, PG::BinaryDecoder::TimestampLocal
-						@conn.type_map_for_results = PG::BasicTypeMapForResults.new(@conn)
+						expect_to_typecase_result_value_warning do
+							@conn.type_map_for_results = PG::BasicTypeMapForResults.new(@conn)
+						end
 						res = @conn.exec_params( "SELECT CAST('2013-07-31 23:58:59' AS TIMESTAMP WITHOUT TIME ZONE),
 																			CAST('1913-12-31 23:58:59.1231' AS TIMESTAMP WITHOUT TIME ZONE),
 																			CAST('4714-11-24 23:58:59.1231-03 BC' AS TIMESTAMP WITHOUT TIME ZONE),


### PR DESCRIPTION
This PR is to suppress unnecessary warnings in the testing result.

https://github.com/ged/ruby-pg/pull/35#issue-267538593
> As a default behavior of the testing command, there are messages for the stdout and stderr like this.
This situation makes us harder to find a real warning issue like this issue.

`STDERR` does not work. It is not captured by the RSpec stderr testing method.
But `$stderr` works.


According to rubocop style guide, `$stderr` is recommended rather than `STDERR`.

https://github.com/rubocop-hq/ruby-style-guide

> Use $stdout/$stderr/$stdin instead of STDOUT/STDERR/STDIN. STDOUT/STDERR/STDIN are constants, and while you can actually reassign (possibly to redirect some stream) constants in Ruby, you'll get an interpreter warning if you do so. 


