### PR TITLE
Suppress warnings.

### DIFF
--- a/spec/helpers.rb
+++ b/spec/helpers.rb
@@ -172,18 +172,18 @@ module PG::TestingHelpers
 			datadir = testdir + 'data'
 			pidfile = datadir + 'postmaster.pid'
 			if pidfile.exist? && pid = pidfile.read.chomp.to_i
-				$stderr.puts "pidfile (%p) exists: %d" % [ pidfile, pid ]
+				trace "pidfile (%p) exists: %d" % [ pidfile, pid ]
 				begin
 					Process.kill( 0, pid )
 				rescue Errno::ESRCH
-					$stderr.puts "No postmaster running for %s" % [ datadir ]
+					trace "No postmaster running for %s" % [ datadir ]
 					# Process isn't alive, so don't try to stop it
 				else
-					$stderr.puts "Stopping lingering database at PID %d" % [ pid ]
+					trace "Stopping lingering database at PID %d" % [ pid ]
 					run 'pg_ctl', '-D', datadir.to_s, '-m', 'fast', 'stop'
 				end
 			else
-				$stderr.puts "No pidfile (%p)" % [ pidfile ]
+				trace "No pidfile (%p)" % [ pidfile ]
 			end
 		end
 	end
@@ -194,7 +194,7 @@ module PG::TestingHelpers
 		require 'pg'
 		stop_existing_postmasters()
 
-		puts "Setting up test database for #{description}"
+		trace "Setting up test database for #{description}"
 		@test_pgdata = TEST_DIRECTORY + 'data'
 		@test_pgdata.mkpath
 
@@ -209,7 +209,7 @@ module PG::TestingHelpers
 		begin
 			unless (@test_pgdata+"postgresql.conf").exist?
 				FileUtils.rm_rf( @test_pgdata, :verbose => $DEBUG )
-				$stderr.puts "Running initdb"
+				trace "Running initdb"
 				log_and_run @logfile, 'initdb', '-E', 'UTF8', '--no-locale', '-D', @test_pgdata.to_s
 			end
 
@@ -218,7 +218,7 @@ module PG::TestingHelpers
 				'-D', @test_pgdata.to_s, 'start'
 			sleep 2
 
-			$stderr.puts "Creating the test DB"
+			trace "Creating the test DB"
 			log_and_run @logfile, 'psql', '-e', '-c', 'DROP DATABASE IF EXISTS test', 'postgres'
 			log_and_run @logfile, 'createdb', '-e', 'test'
 
@@ -239,7 +239,7 @@ module PG::TestingHelpers
 
 
 	def teardown_testing_db( conn )
-		puts "Tearing down test database"
+		trace "Tearing down test database"
 
 		if conn
 			check_for_lingering_connections( conn )

--- a/spec/pg/connection_spec.rb
+++ b/spec/pg/connection_spec.rb
@@ -288,7 +288,8 @@ describe PG::Connection do
 		expect( @conn.host ).to eq( "localhost" )
 	end
 
-	EXPECTED_TRACE_OUTPUT = %{
+	let(:expected_trace_output) do
+		%{
 		To backend> Msg Q
 		To backend> "SELECT 1 AS one"
 		To backend> Msg complete, length 21
@@ -316,6 +317,7 @@ describe PG::Connection do
 		From backend (#4)> 5
 		From backend> T
 		}.gsub( /^\t{2}/, '' ).lstrip
+	end
 
 	it "trace and untrace client-server communication", :unix do
 			# be careful to explicitly close files so that the
@@ -341,7 +343,7 @@ describe PG::Connection do
 			#  From backend> T
 			trace_data.sub!( /(From backend> Z\nFrom backend \(#4\)> 5\n){3}/m, '\\1\\1' )
 
-			expect( trace_data ).to eq( EXPECTED_TRACE_OUTPUT )
+			expect( trace_data ).to eq( expected_trace_output )
 		end
 
 	it "allows a query to be cancelled" do


### PR DESCRIPTION
Suppress warnings part 2.

## Change operation message from $stderr.puts to trace method.
 
Use ruby -w or rspec -w to see the trace log.

trace log is outputted when `$VERBOSE` is true.
When we want to show the trace log, we can show it like this.

```
$ bundle exec rspec -w
```

or

```
$ bundle exec ruby -w -S rspec
```

or

spec/helpers.rb

```
RSpec.configure do |config|
  ..
  config.warnings = true
   ..
end
```

## Fix EXPECTED_TRACE_OUTPUT warning in connection_spec.rb.

Fix blow warnings shown at the top of the log.

```
/home/travis/build/ged/ruby-pg/spec/pg/connection_spec.rb:291: warning: already initialized constant EXPECTED_TRACE_OUTPUT
/home/travis/build/ged/ruby-pg/spec/pg/connection_spec.rb:291: warning: previous definition of EXPECTED_TRACE_OUTPUT was here
```

Now only 2 types of warnings: `WARNING:  there is no transaction in progress` and `WARNING:  there is already a transaction in progress` from somewhere of the logic.
It looks warnings from PostgreSQL.
