### PR TITLE
Assign a random testing port to consider a multi tests case on a same host

### DIFF
--- a/spec/helpers.rb
+++ b/spec/helpers.rb
@@ -198,7 +198,7 @@ module PG::TestingHelpers
 		@test_pgdata = TEST_DIRECTORY + 'data'
 		@test_pgdata.mkpath
 
-		ENV['PGPORT'] ||= "54321"
+		ENV['PGPORT'] ||= (54321 + rand(1000)).to_s
 		@port = ENV['PGPORT'].to_i
 		ENV['PGHOST'] = 'localhost'
 		@conninfo = "host=localhost port=#{@port} dbname=test"


### PR DESCRIPTION
I like to suggest this feature for testing port.

There is a case of failed test for ruby-pg on a build system in our company.

There are some ruby-pg directories in same host
to build and run test on different arch condition.
Then those directories' tests are executed in parallel.

For the case, `tmp_test_specs/setup.log` shows below error
when starting PostgreSQL from spec/helpers.rb.
Because the tests are using same testing port for each other.

```
waiting for server to start....2019-05-13 16:25:07.565 UTC [2106] LOG:
 could not bind IPv6 address "::1": Address already in use
2019-05-13 16:25:07.565 UTC [2106] HINT:  Is another postmaster
already running on port 54321? If not, wait a few seconds and retry.
```

Assigning random port fixes the situation's issue.
As `rand(1000)` returns between 0 and 999,  the logic `54321 + rand(1000)` to set port number is to set port between 54321 and 55320.

Are you fine for this feature?
I appreciate if it is approved for you.
