### PR TITLE
Change i386 case to use standard i386/ubuntu:bionic

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ matrix:
       env:
         - PGPATH="/usr/lib/postgresql/10/bin"
       before_install: |
-        docker run --rm --privileged multiarch/qemu-user-static:register --reset &&
+        docker run --rm --privileged multiarch/qemu-user-static --reset -p yes &&
           docker build --rm --build-arg PGPATH="${PGPATH}" -t ruby-pg -f spec/env/Dockerfile.i386 .
       script: |
         docker run --rm -t --network=host ruby-pg

--- a/spec/env/Dockerfile.i386
+++ b/spec/env/Dockerfile.i386
@@ -1,9 +1,11 @@
-FROM multiarch/ubuntu-debootstrap:i386-bionic
+FROM i386/ubuntu:bionic
 
 ARG PGPATH
 
 ENV PATH "${PGPATH}:${PATH}"
 ENV TEST_USER ruby-pg
+# To prevent installed tzdata deb package to show interactive dialog.
+ENV DEBIAN_FRONTEND noninteractive
 
 WORKDIR /build
 COPY . .


### PR DESCRIPTION
This PR is to update Travis CI i386 case with new recommended way.

The used `multiarch/qemu-user-static` image is recommending new way to use not compatible "multiarch/*" arch image, but standard arch image

Ref: https://github.com/multiarch/qemu-user-static

Here is the Ubuntu standard i386 image.
https://hub.docker.com/_/ubuntu Supported architectures links "i386",
https://hub.docker.com/r/i386/ubuntu/

I added below line in `Dockerfile.i386` as I faced installed tzdata deb package asking interactive dialog during the process of the installation, seeing this URL https://askubuntu.com/questions/909277/avoiding-user-interaction-with-tzdata-when-installing-certbot-in-a-docker-contai .

```
+# To prevent installed tzdata deb package to show interactive dialog.
+ENV DEBIAN_FRONTEND noninteractive
```

```
Setting up tzdata (2019b-0ubuntu0.18.04) ...
debconf: unable to initialize frontend: Dialog
debconf: (TERM is not set, so the dialog frontend is not usable.)
debconf: falling back to frontend: Readline
Configuring tzdata
------------------
Please select the geographic area in which you live. Subsequent configuration
questions will narrow this down by presenting a list of cities, representing
the time zones in which they are located.
  1. Africa      4. Australia  7. Atlantic  10. Pacific  13. Etc
  2. America     5. Arctic     8. Europe    11. SystemV
  3. Antarctica  6. Asia       9. Indian    12. US
Geographic area:
```

Thanks.