### PR TITLE
Ensure valid PG::Result data pointer

### DIFF
--- a/ext/pg.h
+++ b/ext/pg.h
@@ -330,12 +330,7 @@ VALUE pg_tuple_new                                     _(( VALUE, int ));
 static inline t_pg_result *
 pgresult_get_this( VALUE self )
 {
-	t_pg_result *this = RTYPEDDATA_DATA(self);
-
-	if( this == NULL )
-		rb_raise(rb_ePGerror, "result has been cleared");
-
-	return this;
+	return RTYPEDDATA_DATA(self);
 }
 
 


### PR DESCRIPTION
Allocation of the ruby typed data object VALUE is now done within the function that assigns the PGresult retrieved from libpq. Therefore the data pointer of the PG::Result instance is always valid.
There's no need to check the 'this' pointer at every use any longer.

These 'this' pointer checks were introduced at commit de2487c928db6228a701074f4572f438284a717c, when we moved to a variable size data memory. This variable memory allows us to store the field_names once per PG::Result and reuse them several times. However this also moved the memory allocation out of PG::Result#allocate, so that we had to check for validity of the pointer.

This patch removes `PG::Result.allocate` and `PG::Result.new`, which is obvoiusly an API change. However although these methods were callable, the resulting object wasn't usable at all. Not even `PG::Result#inspect` did work. I therefore beleave that no one out there calls these methods and that we are safe to remove them within the pg-1.x series.

This also changes the base class of PG::Result to rb_cData as [recommended in Ruby MRI](https://github.com/ruby/ruby/blob/c3dd3b95538a641bbffb02993985ce0cbac1b9d6/doc/extension.rdoc#user-content-c-struct-to-ruby-object). This change undefs the alloc function internally. It is also visible in ruby space: `PG::Result.ancestors` changes from
`[PG::Result, PG::Constants, Enumerable, Object, JSON::Ext::Generator::GeneratorMethods::Object, Kernel, BasicObject]` to
`[PG::Result, PG::Constants, Enumerable, Data, Object, JSON::Ext::Generator::GeneratorMethods::Object, Kernel, BasicObject]` .
I also think that this is no change that legitimate a jump to pg-2.0.

@ged, @cbandy Is it OK for you to merge this?
