### PR TITLE
Change URLs to point to Github

### DIFF
--- a/README-Windows.rdoc
+++ b/README-Windows.rdoc
@@ -35,8 +35,8 @@ Binary gems for windows can be built on Linux, OS-X and even on Windows
 with the help of docker. This is how regular windows gems are built for
 rubygems.org .
 
-To do this, install boot2docker [on Windows](https://github.com/boot2docker/windows-installer/releases)
-or [on OS X](https://github.com/boot2docker/osx-installer/releases) and make
+To do this, install boot2docker {on Windows}(https://github.com/boot2docker/windows-installer/releases)
+or {on OS X}(https://github.com/boot2docker/osx-installer/releases) and make
 sure it is started. A native Docker installation is best on Linux.
 
 Then run:
@@ -50,7 +50,7 @@ containing binaries for all supported ruby versions.
 
 == Reporting Problems
 
-If you have any problems you can submit them via
-[the project's issue-tracker][bitbucket]. And submit questions, problems, or
+If you have any problems you can submit them via {the project's
+issue-tracker}[https://github.com/ged/ruby-pg/issues]. And submit questions, problems, or
 solutions, so that it can be improved.
 

--- a/README-Windows.rdoc
+++ b/README-Windows.rdoc
@@ -35,8 +35,8 @@ Binary gems for windows can be built on Linux, OS-X and even on Windows
 with the help of docker. This is how regular windows gems are built for
 rubygems.org .
 
-To do this, install boot2docker {on Windows}(https://github.com/boot2docker/windows-installer/releases)
-or {on OS X}(https://github.com/boot2docker/osx-installer/releases) and make
+To do this, install boot2docker {on Windows}[https://github.com/boot2docker/windows-installer/releases]
+or {on OS X}[https://github.com/boot2docker/osx-installer/releases] and make
 sure it is started. A native Docker installation is best on Linux.
 
 Then run:

--- a/README.ja.rdoc
+++ b/README.ja.rdoc
@@ -1,7 +1,6 @@
 = pg
 
-home :: https://bitbucket.org/ged/ruby-pg
-mirror :: https://github.com/ged/ruby-pg
+home :: https://github.com/ged/ruby-pg
 docs :: http://deveiate.org/code/pg
 
 

--- a/README.rdoc
+++ b/README.rdoc
@@ -1,7 +1,6 @@
 = pg
 
-home :: https://bitbucket.org/ged/ruby-pg
-mirror :: https://github.com/ged/ruby-pg
+home :: https://github.com/ged/ruby-pg
 docs :: http://deveiate.org/code/pg
 
 {<img src="https://badges.gitter.im/Join%20Chat.svg" alt="Join the chat at https://gitter.im/ged/ruby-pg">}[https://gitter.im/ged/ruby-pg?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge]
@@ -78,7 +77,7 @@ There's also {a Google+ group}[http://goo.gl/TFy1U] and a
 want to chat about something.
 
 If you want to install as a signed gem, the public certs of the gem signers
-can be found in {the `certs` directory}[https://bitbucket.org/ged/ruby-pg/src/tip/certs/]
+can be found in {the `certs` directory}[https://github.com/ged/ruby-pg/tree/master/certs]
 of the repository.
 
 

--- a/README.rdoc
+++ b/README.rdoc
@@ -147,7 +147,7 @@ Lars Kanis <lars@greiz-reinsdorf.de>.
 
 == Copying
 
-Copyright (c) 1997-2016 by the authors.
+Copyright (c) 1997-2019 by the authors.
 
 * Jeff Davis <ruby-pg@j-davis.com>
 * Guy Decoux (ts) <decoux@moulon.inra.fr>

--- a/ext/pg.c
+++ b/ext/pg.c
@@ -16,7 +16,7 @@
  * See Contributors.rdoc for the many additional fine people that have contributed
  * to this library over the years.
  *
- * Copyright (c) 1997-2016 by the authors.
+ * Copyright (c) 1997-2019 by the authors.
  *
  * You may redistribute this software under the same terms as Ruby itself; see
  * https://www.ruby-lang.org/en/about/license.txt or the BSDL file in the source

--- a/misc/postgres/README.txt
+++ b/misc/postgres/README.txt
@@ -1,6 +1,6 @@
 = postgres
 
-* https://bitbucket.org/ged/ruby-pg
+* https://github.com/ged/ruby-pg
 
 == Description
 

--- a/misc/ruby-pg/README.txt
+++ b/misc/ruby-pg/README.txt
@@ -1,6 +1,6 @@
 = ruby-pg
 
-* https://bitbucket.org/ged/ruby-pg
+* https://github.com/ged/ruby-pg
 
 == Description
 


### PR DESCRIPTION
Since Bitbucket is shutting down support for Mercurial, and most of the work is done via git nowadays, there’s no reason to keep ruby-pg there any longer.