### PR TITLE
The taint mechanism will be deprecated in Ruby 2.7

### DIFF
--- a/ext/pg.h
+++ b/ext/pg.h
@@ -308,11 +308,6 @@ char *pg_rb_str_ensure_capa                            _(( VALUE, long, char *, 
 		(curr_ptr) = (end_ptr) = RSTRING_PTR(str) \
 	)
 
-#define PG_RB_TAINTED_STR_NEW( str, curr_ptr, end_ptr ) ( \
-		(str) = rb_tainted_str_new( NULL, 0 ), \
-		(curr_ptr) = (end_ptr) = RSTRING_PTR(str) \
-	)
-
 VALUE pg_typemap_fit_to_result                         _(( VALUE, VALUE ));
 VALUE pg_typemap_fit_to_query                          _(( VALUE, VALUE ));
 int pg_typemap_fit_to_copy_get                         _(( VALUE ));

--- a/ext/pg_binary_decoder.c
+++ b/ext/pg_binary_decoder.c
@@ -95,7 +95,7 @@ VALUE
 pg_bin_dec_bytea(t_pg_coder *conv, const char *val, int len, int tuple, int field, int enc_idx)
 {
 	VALUE ret;
-	ret = rb_tainted_str_new( val, len );
+	ret = rb_str_new( val, len );
 	PG_ENCODING_SET_NOCHECK( ret, rb_ascii8bit_encindex() );
 	return ret;
 }
@@ -113,7 +113,7 @@ pg_bin_dec_to_base64(t_pg_coder *conv, const char *val, int len, int tuple, int 
 	t_pg_coder_dec_func dec_func = pg_coder_dec_func(this->elem, this->comp.format);
 	int encoded_len = BASE64_ENCODED_SIZE(len);
 	/* create a buffer of the encoded length */
-	VALUE out_value = rb_tainted_str_new(NULL, encoded_len);
+	VALUE out_value = rb_str_new(NULL, encoded_len);
 
 	base64_encode( RSTRING_PTR(out_value), val, len );
 

--- a/ext/pg_connection.c
+++ b/ext/pg_connection.c
@@ -629,7 +629,7 @@ pgconn_db(VALUE self)
 {
 	char *db = PQdb(pg_get_pgconn(self));
 	if (!db) return Qnil;
-	return rb_tainted_str_new2(db);
+	return rb_str_new2(db);
 }
 
 /*
@@ -643,7 +643,7 @@ pgconn_user(VALUE self)
 {
 	char *user = PQuser(pg_get_pgconn(self));
 	if (!user) return Qnil;
-	return rb_tainted_str_new2(user);
+	return rb_str_new2(user);
 }
 
 /*
@@ -657,7 +657,7 @@ pgconn_pass(VALUE self)
 {
 	char *user = PQpass(pg_get_pgconn(self));
 	if (!user) return Qnil;
-	return rb_tainted_str_new2(user);
+	return rb_str_new2(user);
 }
 
 /*
@@ -671,7 +671,7 @@ pgconn_host(VALUE self)
 {
 	char *host = PQhost(pg_get_pgconn(self));
 	if (!host) return Qnil;
-	return rb_tainted_str_new2(host);
+	return rb_str_new2(host);
 }
 
 /*
@@ -698,7 +698,7 @@ pgconn_tty(VALUE self)
 {
 	char *tty = PQtty(pg_get_pgconn(self));
 	if (!tty) return Qnil;
-	return rb_tainted_str_new2(tty);
+	return rb_str_new2(tty);
 }
 
 /*
@@ -712,7 +712,7 @@ pgconn_options(VALUE self)
 {
 	char *options = PQoptions(pg_get_pgconn(self));
 	if (!options) return Qnil;
-	return rb_tainted_str_new2(options);
+	return rb_str_new2(options);
 }
 
 
@@ -793,7 +793,7 @@ pgconn_parameter_status(VALUE self, VALUE param_name)
 	if(ret == NULL)
 		return Qnil;
 	else
-		return rb_tainted_str_new2(ret);
+		return rb_str_new2(ret);
 }
 
 /*
@@ -838,7 +838,7 @@ pgconn_error_message(VALUE self)
 {
 	char *error = PQerrorMessage(pg_get_pgconn(self));
 	if (!error) return Qnil;
-	return rb_tainted_str_new2(error);
+	return rb_str_new2(error);
 }
 
 /*
@@ -2230,9 +2230,9 @@ pgconn_notifies(VALUE self)
 	}
 
 	hash = rb_hash_new();
-	relname = rb_tainted_str_new2(notification->relname);
+	relname = rb_str_new2(notification->relname);
 	be_pid = INT2NUM(notification->be_pid);
-	extra = rb_tainted_str_new2(notification->extra);
+	extra = rb_str_new2(notification->extra);
 	PG_ENCODING_SET_NOCHECK( relname, this->enc_idx );
 	PG_ENCODING_SET_NOCHECK( extra, this->enc_idx );
 
@@ -2428,11 +2428,11 @@ pgconn_wait_for_notify(int argc, VALUE *argv, VALUE self)
 	/* Return nil if the select timed out */
 	if ( !pnotification ) return Qnil;
 
-	relname = rb_tainted_str_new2( pnotification->relname );
+	relname = rb_str_new2( pnotification->relname );
 	PG_ENCODING_SET_NOCHECK( relname, this->enc_idx );
 	be_pid = INT2NUM( pnotification->be_pid );
 	if ( *pnotification->extra ) {
-		extra = rb_tainted_str_new2( pnotification->extra );
+		extra = rb_str_new2( pnotification->extra );
 		PG_ENCODING_SET_NOCHECK( extra, this->enc_idx );
 	}
 	PQfreemem( pnotification );
@@ -2620,7 +2620,7 @@ pgconn_get_copy_data(int argc, VALUE *argv, VALUE self )
 		t_pg_coder_dec_func dec_func = pg_coder_dec_func( p_coder, p_coder->format );
 		result =  dec_func( p_coder, buffer, ret, 0, 0, this->enc_idx );
 	} else {
-		result = rb_tainted_str_new(buffer, ret);
+		result = rb_str_new(buffer, ret);
 	}
 
 	PQfreemem(buffer);
@@ -2796,7 +2796,7 @@ notice_processor_proxy(void *arg, const char *message)
 	t_pg_connection *this = pg_get_connection( self );
 
 	if (this->notice_receiver != Qnil) {
-		VALUE message_str = rb_tainted_str_new2(message);
+		VALUE message_str = rb_str_new2(message);
 		PG_ENCODING_SET_NOCHECK( message_str, this->enc_idx );
 		rb_funcall(this->notice_receiver, rb_intern("call"), 1, message_str);
 	}
@@ -2855,7 +2855,7 @@ static VALUE
 pgconn_get_client_encoding(VALUE self)
 {
 	char *encoding = (char *)pg_encoding_to_char(PQclientEncoding(pg_get_pgconn(self)));
-	return rb_tainted_str_new2(encoding);
+	return rb_str_new2(encoding);
 }
 
 
@@ -3624,7 +3624,7 @@ pgconn_loread(VALUE self, VALUE in_lo_desc, VALUE in_len)
 		return Qnil;
 	}
 
-	str = rb_tainted_str_new(buffer, ret);
+	str = rb_str_new(buffer, ret);
 	xfree(buffer);
 
 	return str;

--- a/ext/pg_copy_coder.c
+++ b/ext/pg_copy_coder.c
@@ -383,7 +383,7 @@ pg_text_dec_copy_row(t_pg_coder *conv, const char *input_line, int len, int _tup
 
 	/* Allocate a new string with embedded capacity and realloc later with
 	 * exponential growing size when needed. */
-	PG_RB_TAINTED_STR_NEW( field_str, output_ptr, end_capa_ptr );
+	PG_RB_STR_NEW( field_str, output_ptr, end_capa_ptr );
 
 	/* set pointer variables for loop */
 	cur_ptr = input_line;
@@ -545,7 +545,7 @@ pg_text_dec_copy_row(t_pg_coder *conv, const char *input_line, int len, int _tup
 			if( field_value == field_str ){
 				/* Our output string will be send to the user, so we can not reuse
 				 * it for the next field. */
-				PG_RB_TAINTED_STR_NEW( field_str, output_ptr, end_capa_ptr );
+				PG_RB_STR_NEW( field_str, output_ptr, end_capa_ptr );
 			}
 		}
 		/* Reset the pointer to the start of the output/buffer string. */

--- a/ext/pg_record_coder.c
+++ b/ext/pg_record_coder.c
@@ -365,7 +365,7 @@ pg_text_dec_record(t_pg_coder *conv, char *input_line, int len, int _tuple, int 
 
 	/* Allocate a new string with embedded capacity and realloc later with
 	 * exponential growing size when needed. */
-	PG_RB_TAINTED_STR_NEW( field_str, output_ptr, end_capa_ptr );
+	PG_RB_STR_NEW( field_str, output_ptr, end_capa_ptr );
 
 	/* set pointer variables for loop */
 	cur_ptr = input_line;
@@ -434,7 +434,7 @@ pg_text_dec_record(t_pg_coder *conv, char *input_line, int len, int _tuple, int 
 			if( field_value == field_str ){
 				/* Our output string will be send to the user, so we can not reuse
 				 * it for the next field. */
-				PG_RB_TAINTED_STR_NEW( field_str, output_ptr, end_capa_ptr );
+				PG_RB_STR_NEW( field_str, output_ptr, end_capa_ptr );
 			}
 			/* Reset the pointer to the start of the output/buffer string. */
 			output_ptr = RSTRING_PTR(field_str);

--- a/ext/pg_result.c
+++ b/ext/pg_result.c
@@ -414,7 +414,7 @@ static void pgresult_init_fnames(VALUE self)
 		int nfields = PQnfields(this->pgresult);
 
 		for( i=0; i<nfields; i++ ){
-			VALUE fname = rb_tainted_str_new2(PQfname(this->pgresult, i));
+			VALUE fname = rb_str_new2(PQfname(this->pgresult, i));
 			PG_ENCODING_SET_NOCHECK(fname, this->enc_idx);
 			this->fnames[i] = rb_obj_freeze(fname);
 			this->nfields = i + 1;
@@ -483,7 +483,7 @@ static VALUE
 pgresult_res_status(VALUE self, VALUE status)
 {
 	t_pg_result *this = pgresult_get_this_safe(self);
-	VALUE ret = rb_tainted_str_new2(PQresStatus(NUM2INT(status)));
+	VALUE ret = rb_str_new2(PQresStatus(NUM2INT(status)));
 	PG_ENCODING_SET_NOCHECK(ret, this->enc_idx);
 	return ret;
 }
@@ -498,7 +498,7 @@ static VALUE
 pgresult_error_message(VALUE self)
 {
 	t_pg_result *this = pgresult_get_this_safe(self);
-	VALUE ret = rb_tainted_str_new2(PQresultErrorMessage(this->pgresult));
+	VALUE ret = rb_str_new2(PQresultErrorMessage(this->pgresult));
 	PG_ENCODING_SET_NOCHECK(ret, this->enc_idx);
 	return ret;
 }
@@ -558,7 +558,7 @@ pgresult_error_field(VALUE self, VALUE field)
 	VALUE ret = Qnil;
 
 	if ( fieldstr ) {
-		ret = rb_tainted_str_new2( fieldstr );
+		ret = rb_str_new2( fieldstr );
 		PG_ENCODING_SET_NOCHECK( ret, this->enc_idx );
 	}
 
@@ -612,7 +612,7 @@ pgresult_fname(VALUE self, VALUE index)
 		rb_raise(rb_eArgError,"invalid field number %d", i);
 	}
 
-	fname = rb_tainted_str_new2(PQfname(this->pgresult, i));
+	fname = rb_str_new2(PQfname(this->pgresult, i));
 	PG_ENCODING_SET_NOCHECK(fname, this->enc_idx);
 	return rb_obj_freeze(fname);
 }
@@ -914,7 +914,7 @@ static VALUE
 pgresult_cmd_status(VALUE self)
 {
 	t_pg_result *this = pgresult_get_this_safe(self);
-	VALUE ret = rb_tainted_str_new2(PQcmdStatus(this->pgresult));
+	VALUE ret = rb_str_new2(PQcmdStatus(this->pgresult));
 	PG_ENCODING_SET_NOCHECK(ret, this->enc_idx);
 	return ret;
 }

--- a/ext/pg_text_decoder.c
+++ b/ext/pg_text_decoder.c
@@ -89,7 +89,7 @@ pg_text_dec_boolean(t_pg_coder *conv, const char *val, int len, int tuple, int f
 VALUE
 pg_text_dec_string(t_pg_coder *conv, const char *val, int len, int tuple, int field, int enc_idx)
 {
-	VALUE ret = rb_tainted_str_new( val, len );
+	VALUE ret = rb_str_new( val, len );
 	PG_ENCODING_SET_NOCHECK( ret, enc_idx );
 	return ret;
 }
@@ -204,7 +204,7 @@ struct pg_blob_initialization {
 
 static VALUE pg_create_blob(VALUE v) {
 	struct pg_blob_initialization *bi = (struct pg_blob_initialization *)v;
-	return rb_tainted_str_new(bi->blob_string, bi->length);
+	return rb_str_new(bi->blob_string, bi->length);
 }
 
 static VALUE pg_pq_freemem(VALUE mem) {
@@ -563,7 +563,7 @@ pg_text_dec_from_base64(t_pg_coder *conv, const char *val, int len, int tuple, i
 	t_pg_coder_dec_func dec_func = pg_coder_dec_func(this->elem, this->comp.format);
 	int decoded_len;
 	/* create a buffer of the expected decoded length */
-	VALUE out_value = rb_tainted_str_new(NULL, BASE64_DECODED_SIZE(len));
+	VALUE out_value = rb_str_new(NULL, BASE64_DECODED_SIZE(len));
 
 	decoded_len = base64_decode( RSTRING_PTR(out_value), val, len );
 	rb_str_set_len(out_value, decoded_len);

--- a/ext/pg_tuple.c
+++ b/ext/pg_tuple.c
@@ -458,7 +458,6 @@ pg_tuple_load(VALUE self, VALUE a)
 	int dup_names;
 
 	rb_check_frozen(self);
-	rb_check_trusted(self);
 
 	TypedData_Get_Struct(self, t_pg_tuple, &pg_tuple_type, this);
 	if (this)


### PR DESCRIPTION
The Ruby core team decided to deprecate the taint mechanism in Ruby 2.7
and will remove that in Ruby 3.

https://bugs.ruby-lang.org/issues/16131
https://github.com/ruby/ruby/pull/2476

In Ruby 2.7, `Object#{taint,untaint,trust,untrust}` and related
functions in the C-API no longer have an effect (all objects are always
considered untainted), and are now warned deprecation message.

https://buildkite.com/rails/rails/builds/65054#14bdbd8c-d935-4b80-8842-c81266a1a34e/6-8