### PR TITLE
Add extended error message functions of PostgreSQL-9.6

### DIFF
--- a/ext/extconf.rb
+++ b/ext/extconf.rb
@@ -73,9 +73,10 @@ end
 have_func 'PQsetSingleRowMode' or
 	abort "Your PostgreSQL is too old. Either install an older version " +
 	      "of this gem or upgrade your database to at least PostgreSQL-9.2."
-have_func 'PQconninfo'
-have_func 'PQsslAttribute'
-have_func 'PQencryptPasswordConn'
+have_func 'PQconninfo' # since PostgreSQL-9.3
+have_func 'PQresultVerboseErrorMessage' # since PostgreSQL-9.6
+have_func 'PQsslAttribute' # since PostgreSQL-10
+have_func 'PQencryptPasswordConn' # since PostgreSQL-10
 have_func 'PQresultMemorySize' # since PostgreSQL-12
 have_func 'timegm'
 have_func 'rb_gc_adjust_memory_usage'

--- a/ext/extconf.rb
+++ b/ext/extconf.rb
@@ -74,12 +74,12 @@ have_func 'PQsetSingleRowMode' or
 	abort "Your PostgreSQL is too old. Either install an older version " +
 	      "of this gem or upgrade your database to at least PostgreSQL-9.2."
 have_func 'PQconninfo' # since PostgreSQL-9.3
+have_func 'PQsslAttribute' # since PostgreSQL-9.5
 have_func 'PQresultVerboseErrorMessage' # since PostgreSQL-9.6
-have_func 'PQsslAttribute' # since PostgreSQL-10
 have_func 'PQencryptPasswordConn' # since PostgreSQL-10
 have_func 'PQresultMemorySize' # since PostgreSQL-12
 have_func 'timegm'
-have_func 'rb_gc_adjust_memory_usage'
+have_func 'rb_gc_adjust_memory_usage' # since ruby-2.4
 
 # unistd.h confilicts with ruby/win32.h when cross compiling for win32 and ruby 1.9.1
 have_header 'unistd.h'

--- a/ext/pg.c
+++ b/ext/pg.c
@@ -422,7 +422,7 @@ Init_pg_ext()
 	rb_define_const(rb_mPGconstants, "CONNECTION_SSL_STARTUP", INT2FIX(CONNECTION_SSL_STARTUP));
 	/* Negotiating environment-driven parameter settings. */
 	rb_define_const(rb_mPGconstants, "CONNECTION_SETENV", INT2FIX(CONNECTION_SETENV));
-	/* Internal state: connect() needed. */
+	/* Internal state - PG.connect() needed. */
 	rb_define_const(rb_mPGconstants, "CONNECTION_NEEDED", INT2FIX(CONNECTION_NEEDED));
 
 	/******     PG::Connection CLASS CONSTANTS: Nonblocking connection polling status     ******/
@@ -438,15 +438,15 @@ Init_pg_ext()
 
 	/******     PG::Connection CLASS CONSTANTS: Transaction Status     ******/
 
-	/* Transaction is currently idle (#transaction_status) */
+	/* Transaction is currently idle ( Connection#transaction_status ) */
 	rb_define_const(rb_mPGconstants, "PQTRANS_IDLE", INT2FIX(PQTRANS_IDLE));
-	/* Transaction is currently active; query has been sent to the server, but not yet completed. (#transaction_status) */
+	/* Transaction is currently active; query has been sent to the server, but not yet completed. ( Connection#transaction_status ) */
 	rb_define_const(rb_mPGconstants, "PQTRANS_ACTIVE", INT2FIX(PQTRANS_ACTIVE));
-	/* Transaction is currently idle, in a valid transaction block (#transaction_status) */
+	/* Transaction is currently idle, in a valid transaction block ( Connection#transaction_status ) */
 	rb_define_const(rb_mPGconstants, "PQTRANS_INTRANS", INT2FIX(PQTRANS_INTRANS));
-	/* Transaction is currently idle, in a failed transaction block (#transaction_status) */
+	/* Transaction is currently idle, in a failed transaction block ( Connection#transaction_status ) */
 	rb_define_const(rb_mPGconstants, "PQTRANS_INERROR", INT2FIX(PQTRANS_INERROR));
-	/* Transaction's connection is bad (#transaction_status) */
+	/* Transaction's connection is bad ( Connection#transaction_status ) */
 	rb_define_const(rb_mPGconstants, "PQTRANS_UNKNOWN", INT2FIX(PQTRANS_UNKNOWN));
 
 	/******     PG::Connection CLASS CONSTANTS: Error Verbosity     ******/
@@ -493,151 +493,156 @@ Init_pg_ext()
 
 	/******     PG::Connection CLASS CONSTANTS: Large Objects     ******/
 
-	/* Flag for #lo_creat, #lo_open -- open for writing */
+	/* Flag for Connection#lo_creat, Connection#lo_open -- open for writing */
 	rb_define_const(rb_mPGconstants, "INV_WRITE", INT2FIX(INV_WRITE));
-	/* Flag for #lo_creat, #lo_open -- open for reading */
+	/* Flag for Connection#lo_creat, Connection#lo_open -- open for reading */
 	rb_define_const(rb_mPGconstants, "INV_READ", INT2FIX(INV_READ));
-	/* Flag for #lo_lseek -- seek from object start */
+	/* Flag for Connection#lo_lseek -- seek from object start */
 	rb_define_const(rb_mPGconstants, "SEEK_SET", INT2FIX(SEEK_SET));
-	/* Flag for #lo_lseek -- seek from current position */
+	/* Flag for Connection#lo_lseek -- seek from current position */
 	rb_define_const(rb_mPGconstants, "SEEK_CUR", INT2FIX(SEEK_CUR));
-	/* Flag for #lo_lseek -- seek from object end */
+	/* Flag for Connection#lo_lseek -- seek from object end */
 	rb_define_const(rb_mPGconstants, "SEEK_END", INT2FIX(SEEK_END));
 
 	/******     PG::Result CONSTANTS: result status      ******/
 
-	/* #result_status constant: The string sent to the server was empty. */
+	/* Result#result_status constant - The string sent to the server was empty. */
 	rb_define_const(rb_mPGconstants, "PGRES_EMPTY_QUERY", INT2FIX(PGRES_EMPTY_QUERY));
-	/* #result_status constant: Successful completion of a command returning no data. */
+	/* Result#result_status constant - Successful completion of a command returning no data. */
 	rb_define_const(rb_mPGconstants, "PGRES_COMMAND_OK", INT2FIX(PGRES_COMMAND_OK));
-		/* #result_status constant: Successful completion of a command returning data
-	   (such as a SELECT or SHOW). */
+	/* Result#result_status constant - Successful completion of a command returning data (such as a SELECT or SHOW). */
 	rb_define_const(rb_mPGconstants, "PGRES_TUPLES_OK", INT2FIX(PGRES_TUPLES_OK));
-	/* #result_status constant: Copy Out (from server) data transfer started. */
+	/* Result#result_status constant - Copy Out (from server) data transfer started. */
 	rb_define_const(rb_mPGconstants, "PGRES_COPY_OUT", INT2FIX(PGRES_COPY_OUT));
-	/* #result_status constant: Copy In (to server) data transfer started. */
+	/* Result#result_status constant - Copy In (to server) data transfer started. */
 	rb_define_const(rb_mPGconstants, "PGRES_COPY_IN", INT2FIX(PGRES_COPY_IN));
-	/* #result_status constant: The server’s response was not understood. */
+	/* Result#result_status constant - The server’s response was not understood. */
 	rb_define_const(rb_mPGconstants, "PGRES_BAD_RESPONSE", INT2FIX(PGRES_BAD_RESPONSE));
-	/* #result_status constant: A nonfatal error (a notice or warning) occurred. */
+	/* Result#result_status constant - A nonfatal error (a notice or warning) occurred. */
 	rb_define_const(rb_mPGconstants, "PGRES_NONFATAL_ERROR",INT2FIX(PGRES_NONFATAL_ERROR));
-	/* #result_status constant: A fatal error occurred. */
+	/* Result#result_status constant - A fatal error occurred. */
 	rb_define_const(rb_mPGconstants, "PGRES_FATAL_ERROR", INT2FIX(PGRES_FATAL_ERROR));
-	/* #result_status constant: Copy In/Out data transfer in progress. */
+	/* Result#result_status constant - Copy In/Out data transfer in progress. */
 	rb_define_const(rb_mPGconstants, "PGRES_COPY_BOTH", INT2FIX(PGRES_COPY_BOTH));
-	/* #result_status constant: Single tuple from larger resultset. */
+	/* Result#result_status constant - Single tuple from larger resultset. */
 	rb_define_const(rb_mPGconstants, "PGRES_SINGLE_TUPLE", INT2FIX(PGRES_SINGLE_TUPLE));
 
 	/******     Result CONSTANTS: result error field codes      ******/
 
-	/* #result_error_field argument constant: The severity; the field contents
-	 * are ERROR, FATAL, or PANIC (in an error message), or WARNING, NOTICE,
-	 * DEBUG, INFO, or LOG (in a notice message), or a localized translation
-	 * of one of these. Always present.
+	/* Result#result_error_field argument constant
+	 *
+	 * The severity; the field contents are ERROR, FATAL, or PANIC (in an error message), or WARNING, NOTICE, DEBUG, INFO, or LOG (in a notice message), or a localized translation
+	 * of one of these.
+	 * Always present.
 	 */
 	rb_define_const(rb_mPGconstants, "PG_DIAG_SEVERITY", INT2FIX(PG_DIAG_SEVERITY));
 
 #ifdef PG_DIAG_SEVERITY_NONLOCALIZED
-	/* #result_error_field argument constant: The severity; the field contents
-	 * are ERROR, FATAL, or PANIC (in an error message), or WARNING, NOTICE,
-	 * DEBUG, INFO, or LOG (in a notice message). This is identical to the
-	 * PG_DIAG_SEVERITY field except that the contents are never localized.
-	 * This is present only in reports generated by PostgreSQL versions 9.6 and later.
+	/* Result#result_error_field argument constant
+	 *
+	 * The severity; the field contents are ERROR, FATAL, or PANIC (in an error message), or WARNING, NOTICE, DEBUG, INFO, or LOG (in a notice message).
+	 * This is identical to the PG_DIAG_SEVERITY field except that the contents are never localized.
+	 *
+	 * Available since PostgreSQL-9.6
 	 */
 	rb_define_const(rb_mPGconstants, "PG_DIAG_SEVERITY_NONLOCALIZED", INT2FIX(PG_DIAG_SEVERITY_NONLOCALIZED));
 #endif
-
-	/* #result_error_field argument constant: The SQLSTATE code for the
-	 * error. The SQLSTATE code identies the type of error that has occurred;
-	 * it can be used by front-end applications to perform specic operations
-	 * (such as er- ror handling) in response to a particular database
-	 * error. For a list of the possible SQLSTATE codes, see Appendix A.
-	 * This eld is not localizable, and is always present.
+	/* Result#result_error_field argument constant
+	 *
+	 * The SQLSTATE code for the error.
+	 * The SQLSTATE code identies the type of error that has occurred; it can be used by front-end applications to perform specic operations (such as error handling) in response to a particular database error.
+	 * For a list of the possible SQLSTATE codes, see Appendix A.
+	 * This field is not localizable, and is always present.
 	 */
 	rb_define_const(rb_mPGconstants, "PG_DIAG_SQLSTATE", INT2FIX(PG_DIAG_SQLSTATE));
-
-	/* #result_error_field argument constant: The primary human-readable
-	 * error message (typically one line). Always present. */
+	/* Result#result_error_field argument constant
+	 *
+	 * The primary human-readable error message (typically one line).
+	 * Always present. */
 	rb_define_const(rb_mPGconstants, "PG_DIAG_MESSAGE_PRIMARY", INT2FIX(PG_DIAG_MESSAGE_PRIMARY));
-
-	/* #result_error_field argument constant: Detail: an optional secondary
-	 * error message carrying more detail about the problem. Might run to
-	 * multiple lines.
+	/* Result#result_error_field argument constant
+	 *
+	 * Detail: an optional secondary error message carrying more detail about the problem.
+	 * Might run to multiple lines.
 	 */
 	rb_define_const(rb_mPGconstants, "PG_DIAG_MESSAGE_DETAIL", INT2FIX(PG_DIAG_MESSAGE_DETAIL));
-
-	/* #result_error_field argument constant: Hint: an optional suggestion
-	 * what to do about the problem. This is intended to differ from detail
-	 * in that it offers advice (potentially inappropriate) rather than
-	 * hard facts. Might run to multiple lines.
+	/* Result#result_error_field argument constant
+	 *
+	 * Hint: an optional suggestion what to do about the problem.
+	 * This is intended to differ from detail in that it offers advice (potentially inappropriate) rather than hard facts.
+	 * Might run to multiple lines.
 	 */
-
 	rb_define_const(rb_mPGconstants, "PG_DIAG_MESSAGE_HINT", INT2FIX(PG_DIAG_MESSAGE_HINT));
-	/* #result_error_field argument constant: A string containing a decimal
-	 * integer indicating an error cursor position as an index into the
-	 * original statement string. The rst character has index 1, and
-	 * positions are measured in characters not bytes.
+	/* Result#result_error_field argument constant
+	 *
+	 * A string containing a decimal integer indicating an error cursor position as an index into the original statement string.
+	 *
+	 * The first character has index 1, and positions are measured in characters not bytes.
 	 */
-
 	rb_define_const(rb_mPGconstants, "PG_DIAG_STATEMENT_POSITION", INT2FIX(PG_DIAG_STATEMENT_POSITION));
-	/* #result_error_field argument constant: This is dened the same as
-	 * the PG_DIAG_STATEMENT_POSITION eld, but it is used when the cursor
-	 * position refers to an internally generated command rather than the
-	 * one submitted by the client. The PG_DIAG_INTERNAL_QUERY eld will
-	 * always appear when this eld appears.
+	/* Result#result_error_field argument constant
+	 *
+	 * This is defined the same as the PG_DIAG_STATEMENT_POSITION field, but it is used when the cursor position refers to an internally generated command rather than the one submitted by the client.
+	 * The PG_DIAG_INTERNAL_QUERY field will always appear when this field appears.
 	 */
-
 	rb_define_const(rb_mPGconstants, "PG_DIAG_INTERNAL_POSITION", INT2FIX(PG_DIAG_INTERNAL_POSITION));
-	/* #result_error_field argument constant: The text of a failed
-	 * internally-generated command. This could be, for example, a SQL
-	 * query issued by a PL/pgSQL function.
+	/* Result#result_error_field argument constant
+	 *
+	 * The text of a failed internally-generated command.
+	 * This could be, for example, a SQL query issued by a PL/pgSQL function.
 	 */
-
 	rb_define_const(rb_mPGconstants, "PG_DIAG_INTERNAL_QUERY", INT2FIX(PG_DIAG_INTERNAL_QUERY));
-	/* #result_error_field argument constant: An indication of the context
-	 * in which the error occurred. Presently this includes a call stack
-	 * traceback of active procedural language functions and internally-generated
-	 * queries. The trace is one entry per line, most recent rst.
+	/* Result#result_error_field argument constant
+	 *
+	 * An indication of the context in which the error occurred.
+	 * Presently this includes a call stack traceback of active procedural language functions and internally-generated queries.
+	 * The trace is one entry per line, most recent first.
 	 */
-
 	rb_define_const(rb_mPGconstants, "PG_DIAG_CONTEXT", INT2FIX(PG_DIAG_CONTEXT));
-	/* #result_error_field argument constant: The le name of the source-code
-	 * location where the error was reported. */
+	/* Result#result_error_field argument constant
+	 *
+	 * The file name of the source-code location where the error was reported. */
 	rb_define_const(rb_mPGconstants, "PG_DIAG_SOURCE_FILE", INT2FIX(PG_DIAG_SOURCE_FILE));
 
-	/* #result_error_field argument constant: The line number of the
-	 * source-code location where the error was reported. */
+	/* Result#result_error_field argument constant
+	 *
+	 * The line number of the source-code location where the error was reported. */
 	rb_define_const(rb_mPGconstants, "PG_DIAG_SOURCE_LINE", INT2FIX(PG_DIAG_SOURCE_LINE));
 
-	/* #result_error_field argument constant: The name of the source-code
-	 * function reporting the error. */
+	/* Result#result_error_field argument constant
+	 *
+	 * The name of the source-code function reporting the error. */
 	rb_define_const(rb_mPGconstants, "PG_DIAG_SOURCE_FUNCTION", INT2FIX(PG_DIAG_SOURCE_FUNCTION));
 
 #ifdef PG_DIAG_TABLE_NAME
-	/* #result_error_field argument constant: If the error was associated with a
-	 * specific database object, the name of the schema containing that object, if any. */
+	/* Result#result_error_field argument constant
+	 *
+	 * If the error was associated with a specific database object, the name of the schema containing that object, if any. */
 	rb_define_const(rb_mPGconstants, "PG_DIAG_SCHEMA_NAME", INT2FIX(PG_DIAG_SCHEMA_NAME));
 
-	/* #result_error_field argument constant: If the error was associated with a
-	 *specific table, the name of the table. (When this field is present, the schema name
-	 * field provides the name of the table's schema.) */
+	/* Result#result_error_field argument constant
+	 *
+	 * If the error was associated with a specific table, the name of the table.
+	 * (When this field is present, the schema name field provides the name of the table's schema.) */
 	rb_define_const(rb_mPGconstants, "PG_DIAG_TABLE_NAME", INT2FIX(PG_DIAG_TABLE_NAME));
 
-	/* #result_error_field argument constant: If the error was associated with a
-	 * specific table column, the name of the column. (When this field is present, the
-	 * schema and table name fields identify the table.) */
+	/* Result#result_error_field argument constant
+	 *
+	 * If the error was associated with a specific table column, the name of the column.
+	 * (When this field is present, the schema and table name fields identify the table.) */
 	rb_define_const(rb_mPGconstants, "PG_DIAG_COLUMN_NAME", INT2FIX(PG_DIAG_COLUMN_NAME));
 
-	/* #result_error_field argument constant: If the error was associated with a
-	 * specific datatype, the name of the datatype. (When this field is present, the
-	 * schema name field provides the name of the datatype's schema.) */
+	/* Result#result_error_field argument constant
+	 *
+	 * If the error was associated with a specific datatype, the name of the datatype.
+	 * (When this field is present, the schema name field provides the name of the datatype's schema.) */
 	rb_define_const(rb_mPGconstants, "PG_DIAG_DATATYPE_NAME", INT2FIX(PG_DIAG_DATATYPE_NAME));
 
-	/* #result_error_field argument constant: If the error was associated with a
-	 * specific constraint, the name of the constraint. The table or domain that the
-	 * constraint belongs to is reported using the fields listed above. (For this
-	 * purpose, indexes are treated as constraints, even if they weren't created with
-	 * constraint syntax.) */
+	/* Result#result_error_field argument constant
+	 *
+	 * If the error was associated with a specific constraint, the name of the constraint.
+	 * The table or domain that the constraint belongs to is reported using the fields listed above.
+	 * (For this purpose, indexes are treated as constraints, even if they weren't created with constraint syntax.) */
 	rb_define_const(rb_mPGconstants, "PG_DIAG_CONSTRAINT_NAME", INT2FIX(PG_DIAG_CONSTRAINT_NAME));
 #endif
 

--- a/ext/pg.c
+++ b/ext/pg.c
@@ -451,12 +451,31 @@ Init_pg_ext()
 
 	/******     PG::Connection CLASS CONSTANTS: Error Verbosity     ******/
 
-	/* Terse error verbosity level (#set_error_verbosity) */
+	/* Terse error verbosity level (#set_error_verbosity).
+	 * In TERSE mode, returned messages include severity, primary text, and position only; this will normally fit on a single line. */
 	rb_define_const(rb_mPGconstants, "PQERRORS_TERSE", INT2FIX(PQERRORS_TERSE));
-	/* Default error verbosity level (#set_error_verbosity) */
+	/* Default error verbosity level (#set_error_verbosity).
+	 * The DEFAULT mode produces messages that include the above plus any detail, hint, or context fields (these might span multiple lines). */
 	rb_define_const(rb_mPGconstants, "PQERRORS_DEFAULT", INT2FIX(PQERRORS_DEFAULT));
-	/* Verbose error verbosity level (#set_error_verbosity) */
+	/* Verbose error verbosity level (#set_error_verbosity).
+	 * The VERBOSE mode includes all available fields. */
 	rb_define_const(rb_mPGconstants, "PQERRORS_VERBOSE", INT2FIX(PQERRORS_VERBOSE));
+
+/* PQERRORS_SQLSTATE was introduced in PG-12 together with PQresultMemorySize() */
+#ifdef HAVE_PQRESULTMEMORYSIZE
+	/* Verbose error verbosity level (#set_error_verbosity).
+	 * The SQLSTATE mode includes only the error severity and the SQLSTATE error code, if one is available (if not, the output is like TERSE mode).
+	 *
+	 * Since PostgreSQL-12.
+	 */
+	rb_define_const(rb_mPGconstants, "PQERRORS_SQLSTATE", INT2FIX(PQERRORS_SQLSTATE));
+#endif
+
+#ifdef HAVE_PQRESULTVERBOSEERRORMESSAGE
+	rb_define_const(rb_mPGconstants, "PQSHOW_CONTEXT_NEVER", INT2FIX(PQSHOW_CONTEXT_NEVER));
+	rb_define_const(rb_mPGconstants, "PQSHOW_CONTEXT_ERRORS", INT2FIX(PQSHOW_CONTEXT_ERRORS));
+	rb_define_const(rb_mPGconstants, "PQSHOW_CONTEXT_ALWAYS", INT2FIX(PQSHOW_CONTEXT_ALWAYS));
+#endif
 
 	/******     PG::Connection CLASS CONSTANTS: Check Server Status ******/
 

--- a/ext/pg.c
+++ b/ext/pg.c
@@ -451,29 +451,32 @@ Init_pg_ext()
 
 	/******     PG::Connection CLASS CONSTANTS: Error Verbosity     ******/
 
-	/* Terse error verbosity level (#set_error_verbosity).
+	/* Error verbosity level ( Connection#set_error_verbosity ).
 	 * In TERSE mode, returned messages include severity, primary text, and position only; this will normally fit on a single line. */
 	rb_define_const(rb_mPGconstants, "PQERRORS_TERSE", INT2FIX(PQERRORS_TERSE));
-	/* Default error verbosity level (#set_error_verbosity).
+	/* Error verbosity level ( Connection#set_error_verbosity ).
 	 * The DEFAULT mode produces messages that include the above plus any detail, hint, or context fields (these might span multiple lines). */
 	rb_define_const(rb_mPGconstants, "PQERRORS_DEFAULT", INT2FIX(PQERRORS_DEFAULT));
-	/* Verbose error verbosity level (#set_error_verbosity).
+	/* Error verbosity level ( Connection#set_error_verbosity ).
 	 * The VERBOSE mode includes all available fields. */
 	rb_define_const(rb_mPGconstants, "PQERRORS_VERBOSE", INT2FIX(PQERRORS_VERBOSE));
 
 /* PQERRORS_SQLSTATE was introduced in PG-12 together with PQresultMemorySize() */
 #ifdef HAVE_PQRESULTMEMORYSIZE
-	/* Verbose error verbosity level (#set_error_verbosity).
+	/* Error verbosity level ( Connection#set_error_verbosity ).
 	 * The SQLSTATE mode includes only the error severity and the SQLSTATE error code, if one is available (if not, the output is like TERSE mode).
 	 *
-	 * Since PostgreSQL-12.
+	 * Available since PostgreSQL-12.
 	 */
 	rb_define_const(rb_mPGconstants, "PQERRORS_SQLSTATE", INT2FIX(PQERRORS_SQLSTATE));
 #endif
 
 #ifdef HAVE_PQRESULTVERBOSEERRORMESSAGE
+	/* See Connection#set_error_context_visibility */
 	rb_define_const(rb_mPGconstants, "PQSHOW_CONTEXT_NEVER", INT2FIX(PQSHOW_CONTEXT_NEVER));
+	/* See Connection#set_error_context_visibility */
 	rb_define_const(rb_mPGconstants, "PQSHOW_CONTEXT_ERRORS", INT2FIX(PQSHOW_CONTEXT_ERRORS));
+	/* See Connection#set_error_context_visibility */
 	rb_define_const(rb_mPGconstants, "PQSHOW_CONTEXT_ALWAYS", INT2FIX(PQSHOW_CONTEXT_ALWAYS));
 #endif
 

--- a/ext/pg_connection.c
+++ b/ext/pg_connection.c
@@ -2622,13 +2622,16 @@ pgconn_get_copy_data(int argc, VALUE *argv, VALUE self )
  *
  * Sets connection's verbosity to _verbosity_ and returns
  * the previous setting. Available settings are:
+ *
  * * PQERRORS_TERSE
  * * PQERRORS_DEFAULT
  * * PQERRORS_VERBOSE
  * * PQERRORS_SQLSTATE
  *
- * See also corresponding {libpq function}(https://www.postgresql.org/docs/current/libpq-control.html#LIBPQ-PQSETERRORVERBOSITY).
-
+ * Changing the verbosity does not affect the messages available from already-existing PG::Result objects, only subsequently-created ones.
+ * (But see PG::Result#verbose_error_message if you want to print a previous error with a different verbosity.)
+ *
+ * See also corresponding {libpq function}[https://www.postgresql.org/docs/current/libpq-control.html#LIBPQ-PQSETERRORVERBOSITY].
  */
 static VALUE
 pgconn_set_error_verbosity(VALUE self, VALUE in_verbosity)
@@ -2649,7 +2652,16 @@ pgconn_set_error_verbosity(VALUE self, VALUE in_verbosity)
  * * PQSHOW_CONTEXT_ERRORS
  * * PQSHOW_CONTEXT_ALWAYS
  *
- * See also corresponding {libpq function}(https://www.postgresql.org/docs/current/libpq-control.html#LIBPQ-PQSETERRORCONTEXTVISIBILITY).
+ * This mode controls whether the CONTEXT field is included in messages (unless the verbosity setting is TERSE, in which case CONTEXT is never shown).
+ * The NEVER mode never includes CONTEXT, while ALWAYS always includes it if available.
+ * In ERRORS mode (the default), CONTEXT fields are included only for error messages, not for notices and warnings.
+ *
+ * Changing this mode does not affect the messages available from already-existing PG::Result objects, only subsequently-created ones.
+ * (But see PG::Result#verbose_error_message if you want to print a previous error with a different display mode.)
+ *
+ * See also corresponding {libpq function}[https://www.postgresql.org/docs/current/libpq-control.html#LIBPQ-PQSETERRORCONTEXTVISIBILITY].
+ *
+ * Available since PostgreSQL-9.6
  */
 static VALUE
 pgconn_set_error_context_visibility(VALUE self, VALUE in_context_visibility)

--- a/ext/pg_connection.c
+++ b/ext/pg_connection.c
@@ -427,7 +427,7 @@ pgconn_s_conndefaults(VALUE self)
  * The caller can assume the string doesn't contain any special characters that would require escaping.
  *
  * Available since PostgreSQL-10.
- * See also corresponding {libpq function}(https://www.postgresql.org/docs/current/libpq-misc.html#LIBPQ-PQENCRYPTPASSWORDCONN).
+ * See also corresponding {libpq function}[https://www.postgresql.org/docs/current/libpq-misc.html#LIBPQ-PQENCRYPTPASSWORDCONN].
  */
 static VALUE
 pgconn_encrypt_password(int argc, VALUE *argv, VALUE self)
@@ -4153,6 +4153,10 @@ init_pg_connection()
 	sym_static_symbol = ID2SYM(rb_intern("static_symbol"));
 
 	rb_cPGconn = rb_define_class_under( rb_mPG, "Connection", rb_cObject );
+/* Help rdoc to known the Constants module */
+#if 0
+	rb_mPGconstants = rb_define_module_under( rb_mPG, "Constants" );
+#endif
 	rb_include_module(rb_cPGconn, rb_mPGconstants);
 
 	/******     PG::Connection CLASS METHODS     ******/

--- a/ext/pg_connection.c
+++ b/ext/pg_connection.c
@@ -2625,6 +2625,10 @@ pgconn_get_copy_data(int argc, VALUE *argv, VALUE self )
  * * PQERRORS_TERSE
  * * PQERRORS_DEFAULT
  * * PQERRORS_VERBOSE
+ * * PQERRORS_SQLSTATE
+ *
+ * See also corresponding {libpq function}(https://www.postgresql.org/docs/current/libpq-control.html#LIBPQ-PQSETERRORVERBOSITY).
+
  */
 static VALUE
 pgconn_set_error_verbosity(VALUE self, VALUE in_verbosity)
@@ -2633,6 +2637,28 @@ pgconn_set_error_verbosity(VALUE self, VALUE in_verbosity)
 	PGVerbosity verbosity = NUM2INT(in_verbosity);
 	return INT2FIX(PQsetErrorVerbosity(conn, verbosity));
 }
+
+#ifdef HAVE_PQRESULTVERBOSEERRORMESSAGE
+/*
+ * call-seq:
+ *    conn.set_error_context_visibility( context_visibility ) -> Integer
+ *
+ * Sets connection's context display mode to _context_visibility_ and returns
+ * the previous setting. Available settings are:
+ * * PQSHOW_CONTEXT_NEVER
+ * * PQSHOW_CONTEXT_ERRORS
+ * * PQSHOW_CONTEXT_ALWAYS
+ *
+ * See also corresponding {libpq function}(https://www.postgresql.org/docs/current/libpq-control.html#LIBPQ-PQSETERRORCONTEXTVISIBILITY).
+ */
+static VALUE
+pgconn_set_error_context_visibility(VALUE self, VALUE in_context_visibility)
+{
+	PGconn *conn = pg_get_pgconn(self);
+	PGContextVisibility context_visibility = NUM2INT(in_context_visibility);
+	return INT2FIX(PQsetErrorContextVisibility(conn, context_visibility));
+}
+#endif
 
 /*
  * call-seq:
@@ -4229,6 +4255,9 @@ init_pg_connection()
 
 	/******     PG::Connection INSTANCE METHODS: Control Functions     ******/
 	rb_define_method(rb_cPGconn, "set_error_verbosity", pgconn_set_error_verbosity, 1);
+#ifdef HAVE_PQRESULTVERBOSEERRORMESSAGE
+	rb_define_method(rb_cPGconn, "set_error_context_visibility", pgconn_set_error_context_visibility, 1 );
+#endif
 	rb_define_method(rb_cPGconn, "trace", pgconn_trace, 1);
 	rb_define_method(rb_cPGconn, "untrace", pgconn_untrace, 0);
 

--- a/ext/pg_result.c
+++ b/ext/pg_result.c
@@ -533,6 +533,8 @@ pgresult_error_message(VALUE self)
  *    res.verbose_error_message( verbosity, show_context ) -> String
  *
  * Returns a reformatted version of the error message associated with a PGresult object.
+ *
+ * Available since PostgreSQL-9.6
  */
 static VALUE
 pgresult_verbose_error_message(VALUE self, VALUE verbosity, VALUE show_context)

--- a/ext/pg_result.c
+++ b/ext/pg_result.c
@@ -527,6 +527,32 @@ pgresult_error_message(VALUE self)
 	return ret;
 }
 
+#ifdef HAVE_PQRESULTVERBOSEERRORMESSAGE
+/*
+ * call-seq:
+ *    res.verbose_error_message( verbosity, show_context ) -> String
+ *
+ * Returns a reformatted version of the error message associated with a PGresult object.
+ */
+static VALUE
+pgresult_verbose_error_message(VALUE self, VALUE verbosity, VALUE show_context)
+{
+	t_pg_result *this = pgresult_get_this_safe(self);
+	VALUE ret;
+	char *c_str;
+
+	c_str = PQresultVerboseErrorMessage(this->pgresult, NUM2INT(verbosity), NUM2INT(show_context));
+	if(!c_str)
+		rb_raise(rb_eNoMemError, "insufficient memory to format error message");
+
+	ret = rb_str_new2(c_str);
+	PQfreemem(c_str);
+	PG_ENCODING_SET_NOCHECK(ret, this->enc_idx);
+
+	return ret;
+}
+#endif
+
 /*
  * call-seq:
  *    res.error_field(fieldcode) -> String
@@ -1568,6 +1594,10 @@ init_pg_result()
 	rb_define_method(rb_cPGresult, "res_status", pgresult_res_status, 1);
 	rb_define_method(rb_cPGresult, "error_message", pgresult_error_message, 0);
 	rb_define_alias( rb_cPGresult, "result_error_message", "error_message");
+#ifdef HAVE_PQRESULTVERBOSEERRORMESSAGE
+	rb_define_method(rb_cPGresult, "verbose_error_message", pgresult_verbose_error_message, 2);
+	rb_define_alias( rb_cPGresult, "result_verbose_error_message", "verbose_error_message");
+#endif
 	rb_define_method(rb_cPGresult, "error_field", pgresult_error_field, 1);
 	rb_define_alias( rb_cPGresult, "result_error_field", "error_field" );
 	rb_define_method(rb_cPGresult, "clear", pg_result_clear, 0);

--- a/spec/helpers.rb
+++ b/spec/helpers.rb
@@ -378,4 +378,5 @@ RSpec.configure do |config|
 	config.filter_run_excluding( :postgresql_95 ) if PG.library_version <  90500
 	config.filter_run_excluding( :postgresql_96 ) if PG.library_version <  90600
 	config.filter_run_excluding( :postgresql_10 ) if PG.library_version < 100000
+	config.filter_run_excluding( :postgresql_12 ) if PG.library_version < 120000
 end

--- a/spec/pg/connection_spec.rb
+++ b/spec/pg/connection_spec.rb
@@ -288,6 +288,18 @@ describe PG::Connection do
 		expect( @conn.host ).to eq( "localhost" )
 	end
 
+	it "can set error verbosity" do
+		old = @conn.set_error_verbosity( PG::PQERRORS_TERSE )
+		new = @conn.set_error_verbosity( old )
+		expect( new ).to eq( PG::PQERRORS_TERSE )
+	end
+
+	it "can set error context visibility", :postgresql_96 do
+		old = @conn.set_error_context_visibility( PG::PQSHOW_CONTEXT_NEVER )
+		new = @conn.set_error_context_visibility( old )
+		expect( new ).to eq( PG::PQSHOW_CONTEXT_NEVER )
+	end
+
 	let(:expected_trace_output) do
 		%{
 		To backend> Msg Q

--- a/spec/pg/result_spec.rb
+++ b/spec/pg/result_spec.rb
@@ -317,7 +317,9 @@ describe PG::Result do
 	it "provides a verbose error message", :postgresql_96 do
 		@conn.send_query("SELECT xyz")
 		res = @conn.get_result; @conn.get_result
+		# PQERRORS_TERSE should give a single line result
 		expect( res.verbose_error_message(PG::PQERRORS_TERSE, PG::PQSHOW_CONTEXT_ALWAYS) ).to match(/\A.*\n\z/)
+		# PQERRORS_VERBOSE should give a multi line result
 		expect( res.result_verbose_error_message(PG::PQERRORS_VERBOSE, PG::PQSHOW_CONTEXT_NEVER) ).to match(/\n.*\n/)
 	end
 

--- a/spec/pg/result_spec.rb
+++ b/spec/pg/result_spec.rb
@@ -307,6 +307,26 @@ describe PG::Result do
 		expect( sqlstate ).to eq( 22012 )
 	end
 
+	it "provides the error message" do
+		@conn.send_query("SELECT xyz")
+		res = @conn.get_result; @conn.get_result
+		expect( res.error_message ).to match(/"xyz"/)
+		expect( res.result_error_message ).to match(/"xyz"/)
+	end
+
+	it "provides a verbose error message", :postgresql_96 do
+		@conn.send_query("SELECT xyz")
+		res = @conn.get_result; @conn.get_result
+		expect( res.verbose_error_message(PG::PQERRORS_TERSE, PG::PQSHOW_CONTEXT_ALWAYS) ).to match(/\A.*\n\z/)
+		expect( res.result_verbose_error_message(PG::PQERRORS_VERBOSE, PG::PQSHOW_CONTEXT_NEVER) ).to match(/\n.*\n/)
+	end
+
+	it "provides a verbose error message with SQLSTATE", :postgresql_12 do
+		@conn.send_query("SELECT xyz")
+		res = @conn.get_result; @conn.get_result
+		expect( res.verbose_error_message(PG::PQERRORS_SQLSTATE, PG::PQSHOW_CONTEXT_NEVER) ).to match(/42703/)
+	end
+
 	it "returns the same bytes in binary format that are sent in binary format" do
 		binary_file = File.join(Dir.pwd, 'spec/data', 'random_binary_data')
 		bytes = File.open(binary_file, 'rb').read


### PR DESCRIPTION
I noticed that there are some missing functions and constants regarding error messages.

This adds some new constants and:
* PG::Connection#set_error_context_visibility
* PG::Result#verbose_error_message
* PG::Result#result_verbose_error_message (alias)