### PR TITLE
Accept Integer and Float as input to TextEncoder::Numeric

### DIFF
--- a/lib/pg/text_encoder.rb
+++ b/lib/pg/text_encoder.rb
@@ -30,12 +30,6 @@ module PG
 			end
 		end
 
-		class Numeric < SimpleEncoder
-			def encode(value)
-				value.is_a?(BigDecimal) ? value.to_s('F') : value
-			end
-		end
-
 		class JSON < SimpleEncoder
 			def encode(value)
 				::JSON.generate(value, quirks_mode: true)

--- a/spec/pg/type_spec.rb
+++ b/spec/pg/type_spec.rb
@@ -12,6 +12,7 @@ describe "PG::Type derivations" do
 	let!(:textdec_boolean) { PG::TextDecoder::Boolean.new }
 	let!(:textenc_float) { PG::TextEncoder::Float.new }
 	let!(:textdec_float) { PG::TextDecoder::Float.new }
+	let!(:textenc_numeric) { PG::TextEncoder::Numeric.new }
 	let!(:textenc_string) { PG::TextEncoder::String.new }
 	let!(:textdec_string) { PG::TextDecoder::String.new }
 	let!(:textenc_timestamp) { PG::TextEncoder::TimestampWithoutTimeZone.new }
@@ -360,6 +361,20 @@ describe "PG::Type derivations" do
 				expect( textenc_float.encode(Float::INFINITY) ).to eq( Float::INFINITY.to_s )
 				expect( textenc_float.encode(-Float::INFINITY) ).to eq( (-Float::INFINITY).to_s )
 				expect( textenc_float.encode(-Float::NAN) ).to eq( Float::NAN.to_s )
+			end
+
+			it "should encode various inputs to numeric format" do
+				expect( textenc_numeric.encode(0) ).to eq( "0" )
+				expect( textenc_numeric.encode(1) ).to eq( "1" )
+				expect( textenc_numeric.encode(-12345678901234567890123) ).to eq( "-12345678901234567890123" )
+				expect( textenc_numeric.encode(0.0) ).to eq( "0.0" )
+				expect( textenc_numeric.encode(1.0) ).to eq( "1.0" )
+				expect( textenc_numeric.encode(-1.23456789012e45) ).to eq( "-1.23456789012e45" )
+				expect( textenc_numeric.encode(Float::NAN) ).to eq( Float::NAN.to_s )
+				expect( textenc_numeric.encode(BigDecimal(0)) ).to eq( "0.0" )
+				expect( textenc_numeric.encode(BigDecimal(1)) ).to eq( "1.0" )
+				expect( textenc_numeric.encode(BigDecimal("-12345678901234567890.1234567")) ).to eq( "-12345678901234567890.1234567" )
+				expect( textenc_numeric.encode(" 123 ") ).to eq( " 123 " )
 			end
 
 			it "encodes binary string to bytea" do


### PR DESCRIPTION
Current `TextEncoder::Numeric` doesn't handle other classes than `BigDecimal`. That doesn't bother as long as `BasicTypeMapping` is used directly to encode values, since it selects the encoder based on the input type. However if a type map is generated by `PG::TypeMapByOid#build_column_map` or manually it fails on Integer and Float values. This is fixed with this PR.

This moves the conversion of  BigDecimal` to C, so that we can make use of our fast Integer and Float encoders. They avoid additional string allocations, which a ruby conversion would do.

Fixes #310
