### PR TITLE
Add an overview about coders and type maps to README

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -118,7 +118,8 @@ PG::Coder objects can be used to set up a PG::TypeMap or alternatively
 to convert single values to/from their string representation.
 
 The following PostgreSQL column types are supported by ruby-pg (TE = Text Encoder, TD = Text Decoder, BE = Binary Encoder, BD = Binary Decoder):
-* Integer: {TE}[rdoc-ref:PG::TextEncoder::Integer], {TD}[rdoc-ref:PG::TextDecoder::Integer], {BE2}[rdoc-ref:PG::BinaryEncoder::Int2] {BE4}[rdoc-ref:PG::BinaryEncoder::Int4] {BE8}[rdoc-ref:PG::BinaryEncoder::Int8], {BD}[rdoc-ref:PG::BinaryDecoder::Integer]
+* Integer: {TE}[rdoc-ref:PG::TextEncoder::Integer], {TD}[rdoc-ref:PG::TextDecoder::Integer], {BD}[rdoc-ref:PG::BinaryDecoder::Integer]
+  * BE: {Int2}[rdoc-ref:PG::BinaryEncoder::Int2], {Int4}[rdoc-ref:PG::BinaryEncoder::Int4], {Int8}[rdoc-ref:PG::BinaryEncoder::Int8]
 * Float: {TE}[rdoc-ref:PG::TextEncoder::Float], {TD}[rdoc-ref:PG::TextDecoder::Float], {BD}[rdoc-ref:PG::BinaryDecoder::Float]
 * Numeric: {TE}[rdoc-ref:PG::TextEncoder::Numeric], {TD}[rdoc-ref:PG::TextDecoder::Numeric]
 * Boolean: {TE}[rdoc-ref:PG::TextEncoder::Boolean], {TD}[rdoc-ref:PG::TextDecoder::Boolean], {BE}[rdoc-ref:PG::BinaryEncoder::Boolean], {BD}[rdoc-ref:PG::BinaryDecoder::Boolean]

--- a/README.rdoc
+++ b/README.rdoc
@@ -117,6 +117,29 @@ to build composite types by assigning an element encoder/decoder.
 PG::Coder objects can be used to set up a PG::TypeMap or alternatively
 to convert single values to/from their string representation.
 
+The following PostgreSQL column types are supported by ruby-pg (TE = Text Encoder, TD = Text Decoder, BE = Binary Encoder, BD = Binary Decoder):
+* Integer: {TE}[rdoc-ref:PG::TextEncoder::Integer], {TD}[rdoc-ref:PG::TextDecoder::Integer], {BE2}[rdoc-ref:PG::BinaryEncoder::Int2] {BE4}[rdoc-ref:PG::BinaryEncoder::Int4] {BE8}[rdoc-ref:PG::BinaryEncoder::Int8], {BD}[rdoc-ref:PG::BinaryDecoder::Integer]
+* Float: {TE}[rdoc-ref:PG::TextEncoder::Float], {TD}[rdoc-ref:PG::TextDecoder::Float], {BD}[rdoc-ref:PG::BinaryDecoder::Float]
+* Numeric: {TE}[rdoc-ref:PG::TextEncoder::Numeric], {TD}[rdoc-ref:PG::TextDecoder::Numeric]
+* Boolean: {TE}[rdoc-ref:PG::TextEncoder::Boolean], {TD}[rdoc-ref:PG::TextDecoder::Boolean], {BE}[rdoc-ref:PG::BinaryEncoder::Boolean], {BD}[rdoc-ref:PG::BinaryDecoder::Boolean]
+* String: {TE}[rdoc-ref:PG::TextEncoder::String], {TD}[rdoc-ref:PG::TextDecoder::String], {BE}[rdoc-ref:PG::BinaryEncoder::String], {BD}[rdoc-ref:PG::BinaryDecoder::String]
+* Bytea: {TE}[rdoc-ref:PG::TextEncoder::Bytea], {TD}[rdoc-ref:PG::TextDecoder::Bytea], {BE}[rdoc-ref:PG::BinaryEncoder::Bytea], {BD}[rdoc-ref:PG::BinaryDecoder::Bytea]
+* Base64: {TE}[rdoc-ref:PG::TextEncoder::ToBase64], {TD}[rdoc-ref:PG::TextDecoder::FromBase64], {BE}[rdoc-ref:PG::BinaryEncoder::FromBase64], {BD}[rdoc-ref:PG::BinaryDecoder::ToBase64]
+* Timestamp:
+  * TE: {local}[rdoc-ref:PG::TextEncoder::TimestampWithoutTimeZone], {UTC}[rdoc-ref:PG::TextEncoder::TimestampUtc], {with-TZ}[rdoc-ref:PG::TextEncoder::TimestampWithTimeZone]
+  * TD: {local}[rdoc-ref:PG::TextDecoder::TimestampLocal], {UTC}[rdoc-ref:PG::TextDecoder::TimestampUtc], {UTC-to-local}[rdoc-ref:PG::TextDecoder::TimestampUtcToLocal]
+  * BD: {local}[rdoc-ref:PG::BinaryDecoder::TimestampLocal], {UTC}[rdoc-ref:PG::BinaryDecoder::TimestampUtc], {UTC-to-local}[rdoc-ref:PG::BinaryDecoder::TimestampUtcToLocal]
+* Date: {TE}[rdoc-ref:PG::TextEncoder::Date], {TD}[rdoc-ref:PG::TextDecoder::Date]
+* JSON and JSONB: {TE}[rdoc-ref:PG::TextEncoder::JSON], {TD}[rdoc-ref:PG::TextDecoder::JSON]
+* Inet: {TE}[rdoc-ref:PG::TextEncoder::Inet], {TD}[rdoc-ref:PG::TextDecoder::Inet]
+* Array: {TE}[rdoc-ref:PG::TextEncoder::Array], {TD}[rdoc-ref:PG::TextDecoder::Array]
+* Composite Type (also called "Row" or "Record"): {TE}[rdoc-ref:PG::TextEncoder::Record], {TD}[rdoc-ref:PG::TextDecoder::Record]
+
+The following text formats can also be encoded although they are not used as column type:
+* COPY input and output data: {TE}[rdoc-ref:PG::TextEncoder::CopyRow], {TD}[rdoc-ref:PG::TextDecoder::CopyRow]
+* Literal for insertion into SQL string: {TE}[rdoc-ref:PG::TextEncoder::QuotedLiteral]
+* SQL-Identifier: {TE}[rdoc-ref:PG::TextEncoder::Identifier], {TD}[rdoc-ref:PG::TextDecoder::Identifier]
+
 === PG::TypeMap and derivations (ext/pg_type_map*.c, lib/pg/type_map*.rb)
 
 A TypeMap defines which value will be converted by which encoder/decoder.
@@ -127,6 +150,19 @@ needs for type casting. The default type map is PG::TypeMapAllStrings.
 A type map can be assigned per connection or per query respectively per
 result set. Type maps can also be used for COPY in and out data streaming.
 See PG::Connection#copy_data .
+
+The following base type maps are available:
+* PG::TypeMapAllStrings - encodes and decodes all values to and from strings (default)
+* PG::TypeMapByClass - selects encoder based on the class of the value to be sent
+* PG::TypeMapByColumn - selects encoder and decoder by column order
+* PG::TypeMapByOid - selects decoder by PostgreSQL type OID
+* PG::TypeMapInRuby - define a custom type map in ruby
+
+The following type maps are prefilled with type mappings from the PG::BasicTypeRegistry :
+* PG::BasicTypeMapForResults - a PG::TypeMapByOid prefilled with decoders for common PostgreSQL column types
+* PG::BasicTypeMapBasedOnResult - a PG::TypeMapByOid prefilled with encoders for common PostgreSQL column types
+* PG::BasicTypeMapForQueries - a PG::TypeMapByClass prefilled with encoders for common Ruby value classes
+
 
 == Contributing
 

--- a/ext/pg_binary_decoder.c
+++ b/ext/pg_binary_decoder.c
@@ -17,8 +17,8 @@ VALUE rb_mPG_BinaryDecoder;
 /*
  * Document-class: PG::BinaryDecoder::Boolean < PG::SimpleDecoder
  *
- * This is a decoder class for conversion of PostgreSQL binary bool type
- * to Ruby true or false objects.
+ * This is a decoder class for conversion of PostgreSQL binary +bool+ type
+ * to Ruby +true+ or +false+ objects.
  *
  */
 static VALUE
@@ -33,7 +33,7 @@ pg_bin_dec_boolean(t_pg_coder *conv, const char *val, int len, int tuple, int fi
 /*
  * Document-class: PG::BinaryDecoder::Integer < PG::SimpleDecoder
  *
- * This is a decoder class for conversion of PostgreSQL binary int2, int4 and int8 types
+ * This is a decoder class for conversion of PostgreSQL binary +int2+, +int4+ and +int8+ types
  * to Ruby Integer objects.
  *
  */
@@ -55,7 +55,7 @@ pg_bin_dec_integer(t_pg_coder *conv, const char *val, int len, int tuple, int fi
 /*
  * Document-class: PG::BinaryDecoder::Float < PG::SimpleDecoder
  *
- * This is a decoder class for conversion of PostgreSQL binary float4 and float8 types
+ * This is a decoder class for conversion of PostgreSQL binary +float4+ and +float8+ types
  * to Ruby Float objects.
  *
  */
@@ -87,7 +87,7 @@ pg_bin_dec_float(t_pg_coder *conv, const char *val, int len, int tuple, int fiel
  * Document-class: PG::BinaryDecoder::Bytea < PG::SimpleDecoder
  *
  * This decoder class delivers the data received from the server as binary String object.
- * It is therefore suitable for conversion of PostgreSQL bytea data as well as any other
+ * It is therefore suitable for conversion of PostgreSQL +bytea+ data as well as any other
  * data in binary format.
  *
  */
@@ -103,7 +103,7 @@ pg_bin_dec_bytea(t_pg_coder *conv, const char *val, int len, int tuple, int fiel
 /*
  * Document-class: PG::BinaryDecoder::ToBase64 < PG::CompositeDecoder
  *
- * This is a decoder class for conversion of binary (bytea) to base64 data.
+ * This is a decoder class for conversion of binary +bytea+ to base64 data.
  *
  */
 static VALUE

--- a/ext/pg_binary_encoder.c
+++ b/ext/pg_binary_encoder.c
@@ -39,7 +39,7 @@ pg_bin_enc_boolean(t_pg_coder *conv, VALUE value, char *out, VALUE *intermediate
 /*
  * Document-class: PG::BinaryEncoder::Int2 < PG::SimpleEncoder
  *
- * This is the encoder class for the PostgreSQL int2 type.
+ * This is the encoder class for the PostgreSQL +int2+ (alias +smallint+) type.
  *
  * Non-Number values are expected to have method +to_i+ defined.
  *
@@ -56,9 +56,9 @@ pg_bin_enc_int2(t_pg_coder *conv, VALUE value, char *out, VALUE *intermediate, i
 }
 
 /*
- * Document-class: PG::BinaryEncoder::Int2 < PG::SimpleEncoder
+ * Document-class: PG::BinaryEncoder::Int4 < PG::SimpleEncoder
  *
- * This is the encoder class for the PostgreSQL int4 type.
+ * This is the encoder class for the PostgreSQL +int4+ (alias +integer+) type.
  *
  * Non-Number values are expected to have method +to_i+ defined.
  *
@@ -75,9 +75,9 @@ pg_bin_enc_int4(t_pg_coder *conv, VALUE value, char *out, VALUE *intermediate, i
 }
 
 /*
- * Document-class: PG::BinaryEncoder::Int2 < PG::SimpleEncoder
+ * Document-class: PG::BinaryEncoder::Int8 < PG::SimpleEncoder
  *
- * This is the encoder class for the PostgreSQL int8 type.
+ * This is the encoder class for the PostgreSQL +int8+ (alias +bigint+) type.
  *
  * Non-Number values are expected to have method +to_i+ defined.
  *

--- a/ext/pg_text_encoder.c
+++ b/ext/pg_text_encoder.c
@@ -150,7 +150,7 @@ count_leading_zero_bits(unsigned long long x)
 /*
  * Document-class: PG::TextEncoder::Integer < PG::SimpleEncoder
  *
- * This is the encoder class for the PostgreSQL int types.
+ * This is the encoder class for the PostgreSQL integer types.
  *
  * Non-Integer values are expected to have method +to_i+ defined.
  *
@@ -379,8 +379,7 @@ static const char hextab[] = {
 /*
  * Document-class: PG::TextEncoder::Bytea < PG::SimpleEncoder
  *
- * This is an encoder class for the PostgreSQL bytea type for server version 9.0
- * or newer.
+ * This is an encoder class for the PostgreSQL +bytea+ type.
  *
  * The binary String is converted to hexadecimal representation for transmission
  * in text format. For query bind parameters it is recommended to use


### PR DESCRIPTION
Ideally this should have the format of a table. Unfortunately rdoc doesn't supoort any kind of tables except in the markdown parser. However even the markdown parser supports tables only through raw HTML and doesn't do any automatic linking to internal classes.

I still think such an overview is very helpful for someone who wants to understand or use the type cast system:

![Bildschirmfoto von 2019-12-15 14-27-03](https://user-images.githubusercontent.com/176234/70863317-2ad59180-1f47-11ea-99c1-91524fd575d9.png)

Hope this can be in pg-1.2.0.