### PR TITLE
Add pg_get_result_enc_idx

### DIFF
--- a/ext/pg_result.c
+++ b/ext/pg_result.c
@@ -167,6 +167,11 @@ static const rb_data_type_t pgresult_type = {
 #endif
 };
 
+/* Needed by sequel_pg gem, do not delete */
+int pg_get_result_enc_idx(VALUE self)
+{
+	return pgresult_get_this(self)->enc_idx;
+}
 
 /*
  * Global functions


### PR DESCRIPTION
This can be used by sequel_pg to get the encoding index, as discussed in https://github.com/jeremyevans/sequel_pg/issues/34.

I've prepared an update to sequel_pg to use this function:

```
$ ruby24 -I /data/code/external/ruby-pg/lib bin/sequel postgres:///?user=sequel_test -c 'p $LOADED_FEATURES.grep(/pg.*.so\z/); p DB[:s].get(:s)'
["/data/code/external/ruby-pg/lib/pg_ext.so", "/usr/local/lib/ruby/gems/2.4/gems/sequel_pg-1.12.2/lib/sequel_pg.so"]
"\xE1\x80\x80"
$ ruby24 -I /data/code/sequel_pg/lib -I /data/code/external/ruby-pg/lib bin/sequel postgres:///?user=sequel_test -c 'p $LOADED_FEATURES.grep(/pg.*.so\z/); p DB[:s].get(:s)'
["/data/code/external/ruby-pg/lib/pg_ext.so", "/data/code/sequel_pg/lib/sequel_pg.so"]
"\u1000"
```

I would appreciate it if pg 1.2.1 could be released with this change.

