### PR TITLE
Avoid type cast warning in build_coder_maps

### DIFF
--- a/lib/pg/basic_type_mapping.rb
+++ b/lib/pg/basic_type_mapping.rb
@@ -118,13 +118,13 @@ module PG::BasicTypeRegistry
 	def build_coder_maps(connection)
 		if supports_ranges?(connection)
 			result = connection.exec <<-SQL
-				SELECT t.oid, t.typname, t.typelem, t.typdelim, t.typinput, r.rngsubtype
+				SELECT t.oid, t.typname::text, t.typelem, t.typdelim, t.typinput::text, r.rngsubtype
 				FROM pg_type as t
 				LEFT JOIN pg_range as r ON oid = rngtypid
 			SQL
 		else
 			result = connection.exec <<-SQL
-				SELECT t.oid, t.typname, t.typelem, t.typdelim, t.typinput
+				SELECT t.oid, t.typname::text, t.typelem, t.typdelim, t.typinput::text
 				FROM pg_type as t
 			SQL
 		end

--- a/spec/pg/basic_type_mapping_spec.rb
+++ b/spec/pg/basic_type_mapping_spec.rb
@@ -21,14 +21,6 @@ ensure
 	end
 end
 
-def expect_to_typecase_result_value_warning
-	warning = 'Warning: no type cast defined for type "name" with oid 19. '\
-		"Please cast this type explicitly to TEXT to be safe for future changes.\n"\
-		'Warning: no type cast defined for type "regproc" with oid 24. '\
-		"Please cast this type explicitly to TEXT to be safe for future changes.\n"
-	expect { yield }.to output(warning).to_stderr
-end
-
 describe 'Basic type mapping' do
 
 	describe PG::BasicTypeMapForQueries do
@@ -318,9 +310,7 @@ describe 'Basic type mapping' do
 				it "should convert format #{format} timestamps per TimestampUtc" do
 					restore_type("timestamp") do
 						PG::BasicTypeRegistry.register_type 0, 'timestamp', nil, PG::TextDecoder::TimestampUtc
-						expect_to_typecase_result_value_warning do
-							@conn.type_map_for_results = PG::BasicTypeMapForResults.new(@conn)
-						end
+						@conn.type_map_for_results = PG::BasicTypeMapForResults.new(@conn)
 						res = @conn.exec_params( "SELECT CAST('2013-07-31 23:58:59+02' AS TIMESTAMP WITHOUT TIME ZONE),
 																			CAST('1913-12-31 23:58:59.1231-03' AS TIMESTAMP WITHOUT TIME ZONE),
 																			CAST('4714-11-24 23:58:59.1231-03 BC' AS TIMESTAMP WITHOUT TIME ZONE),
@@ -342,9 +332,7 @@ describe 'Basic type mapping' do
 					restore_type("timestamp") do
 						PG::BasicTypeRegistry.register_type 0, 'timestamp', nil, PG::TextDecoder::TimestampUtcToLocal
 						PG::BasicTypeRegistry.register_type 1, 'timestamp', nil, PG::BinaryDecoder::TimestampUtcToLocal
-						expect_to_typecase_result_value_warning do
-							@conn.type_map_for_results = PG::BasicTypeMapForResults.new(@conn)
-						end
+						@conn.type_map_for_results = PG::BasicTypeMapForResults.new(@conn)
 						res = @conn.exec_params( "SELECT CAST('2013-07-31 23:58:59+02' AS TIMESTAMP WITHOUT TIME ZONE),
 																			CAST('1913-12-31 23:58:59.1231-03' AS TIMESTAMP WITHOUT TIME ZONE),
 																			CAST('4714-11-24 23:58:59.1231-03 BC' AS TIMESTAMP WITHOUT TIME ZONE),
@@ -366,9 +354,7 @@ describe 'Basic type mapping' do
 					restore_type("timestamp") do
 						PG::BasicTypeRegistry.register_type 0, 'timestamp', nil, PG::TextDecoder::TimestampLocal
 						PG::BasicTypeRegistry.register_type 1, 'timestamp', nil, PG::BinaryDecoder::TimestampLocal
-						expect_to_typecase_result_value_warning do
-							@conn.type_map_for_results = PG::BasicTypeMapForResults.new(@conn)
-						end
+						@conn.type_map_for_results = PG::BasicTypeMapForResults.new(@conn)
 						res = @conn.exec_params( "SELECT CAST('2013-07-31 23:58:59' AS TIMESTAMP WITHOUT TIME ZONE),
 																			CAST('1913-12-31 23:58:59.1231' AS TIMESTAMP WITHOUT TIME ZONE),
 																			CAST('4714-11-24 23:58:59.1231-03 BC' AS TIMESTAMP WITHOUT TIME ZONE),


### PR DESCRIPTION
These columns are of text-like types (name, regproc) which are not mapped. Since they’re ultimately just treated as text, follow our own warning and cast them in SQL to avoid a Ruby type cast warning.