### PR TITLE
Fix README example

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -24,7 +24,7 @@ A small example usage:
     puts "     PID | User             | Query"
     result.each do |row|
       puts " %7d | %-16s | %s " %
-        row.values_at('procpid', 'usename', 'current_query')
+        row.values_at('pid', 'usename', 'query')
     end
   end
 


### PR DESCRIPTION
The example fails because the column names `procpid` and `current_query` are incorrect. The correct names are `pid` and `query`.

See: https://www.postgresql.org/docs/current/monitoring-stats.html#PG-STAT-ACTIVITY-VIEW