### PR TITLE
fix test time mapping fails on +800 timezone

### DIFF
--- a/spec/pg/basic_type_mapping_spec.rb
+++ b/spec/pg/basic_type_mapping_spec.rb
@@ -99,7 +99,7 @@ describe 'Basic type mapping' do
 					[Time.new(2019, 12, 8, 20, 38, 12.123, "-01:00")], # Time -> timestamptz[]
 				], nil, basic_type_mapping )
 
-			expect( res.values[0][0] ).to match( /\{\"2019-12-08 \d\d:38:12.123[+-]\d\d\"\}/ )
+			expect( res.values[0][0] ).to match( /\{\"2019-12-0\d \d\d:38:12.123[+-]\d\d\"\}/ )
 			expect( result_typenames(res) ).to eq( ['timestamp with time zone[]'] )
 		end
 


### PR DESCRIPTION
I living in China which +8:00 timezone, there's a test case failure

```
1) Basic type mapping PG::BasicTypeMapForQueries should do default array-as-array param encoding with Time objects
    Failure/Error: expect( res.values[0][0] ).to match( /\{\"2019-12-08 \d\d:38:12.123[+-]\d\d\"\}/ )

      expected "{\"2019-12-09 05:38:12.123+08\"}" to match /\{\"2019-12-08 \d\d:38:12.123[+-]\d\d\"\}/
      Diff:
      @@ -1 +1 @@
      -/\{\"2019-12-08 \d\d:38:12.123[+-]\d\d\"\}/
      +"{\"2019-12-09 05:38:12.123+08\"}"

    # ./spec/pg/basic_type_mapping_spec.rb:102:in `block (3 levels) in <top (required)>'
    # ./spec/helpers.rb:30:in `block in included'
```

this PR should fix the test