### PR TITLE
Avoid casting of OIDs to fix compat with Redshift database

### DIFF
--- a/spec/pg/basic_type_mapping_spec.rb
+++ b/spec/pg/basic_type_mapping_spec.rb
@@ -264,9 +264,10 @@ describe 'Basic type mapping' do
 			it "should do string type conversions" do
 				@conn.internal_encoding = 'utf-8'
 				[1, 0].each do |format|
-					res = @conn.exec_params( "SELECT 'abcäöü'::TEXT", [], format )
-					expect( res.values ).to eq( [['abcäöü']] )
-					expect( res.values[0][0].encoding ).to eq( Encoding::UTF_8 )
+					res = @conn.exec_params( "SELECT 'abcäöü'::TEXT, 'colname'::name", [], format )
+					expect( res.values ).to eq( [['abcäöü', 'colname']] )
+					expect( [res.ftype(0), res.ftype(1)] ).to eq( [25, 19] )
+					expect( res.values[0].map(&:encoding) ).to eq( [Encoding::UTF_8] * 2 )
 				end
 			end
 


### PR DESCRIPTION
Redshift doesn't support OID these casts, so we do OID lookup through the pg_proc table and add type 'name' as an alias for 'text'.

Also clean up the type map generation, so that only arrays are separated and all other types can be registered.

Fixes #369