### PR TITLE
Make the library path of libpq available in ruby and add it to the DLL search paths on Windows which lacks rpath.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ source "https://rubygems.org/"
 gem "hoe-mercurial", "~>1.4", :group => [:development, :test]
 gem "hoe-deveiate", "~>0.9", :group => [:development, :test]
 gem "hoe-highline", "~>0.2", :group => [:development, :test]
-gem "rake-compiler", "~>1.0", :group => [:development, :test]
+gem "rake-compiler", "1.1.1", :group => [:development, :test]
 gem "rake-compiler-dock", "~>1.0", :group => [:development, :test]
 gem "hoe-bundler", "~>1.0", :group => [:development, :test]
 gem "rspec", "~>3.5", :group => [:development, :test]

--- a/Rakefile
+++ b/Rakefile
@@ -6,6 +6,7 @@ require 'tmpdir'
 
 begin
 	require 'rake/extensiontask'
+	require_relative 'misc/rake-compiler-make-install-patch'
 rescue LoadError
 	abort "This Rakefile requires rake-compiler (gem install rake-compiler)"
 end
@@ -63,7 +64,7 @@ $hoespec = Hoe.spec 'pg' do
 	self.developer 'Michael Granger', 'ged@FaerieMUD.org'
 	self.developer 'Lars Kanis', 'lars@greiz-reinsdorf.de'
 
-	self.dependency 'rake-compiler', '~> 1.0', :developer
+	self.dependency 'rake-compiler', '1.1.1', :developer
 	self.dependency 'rake-compiler-dock', ['~> 1.0'], :developer
 	self.dependency 'hoe-deveiate', '~> 0.9', :developer
 	self.dependency 'hoe-bundler', '~> 1.0', :developer

--- a/Rakefile
+++ b/Rakefile
@@ -37,6 +37,7 @@ CLOBBER.include( TESTDIR.to_s )
 CLEAN.include( PKGDIR.to_s, TMPDIR.to_s )
 CLEAN.include "lib/*/libpq.dll"
 CLEAN.include "lib/pg_ext.*"
+CLEAN.include "lib/pg/postgresql_lib_path.rb"
 
 # Set up Hoe plugins
 Hoe.plugin :mercurial

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -19,7 +19,6 @@ install:
         $(new-object net.webclient).DownloadFile('http://get.enterprisedb.com/postgresql/postgresql-' + $env:PGVERSION + '.exe', 'C:/postgresql-setup.exe')
         cmd /c "C:/postgresql-setup.exe" --mode unattended --extract-only 1
       }
-      $env:RUBY_DLL_PATH = 'C:/Program Files/PostgreSQL/' + $env:PGVER + '/bin;C:/Program Files (x86)/PostgreSQL/' + $env:PGVER + '/bin'
       $env:PATH = 'C:/Program Files/PostgreSQL/' + $env:PGVER + '/bin;' + $env:PATH
       $env:PATH = 'C:/Program Files (x86)/PostgreSQL/' + $env:PGVER + '/bin;' + $env:PATH
 build_script:

--- a/misc/rake-compiler-make-install-patch.rb
+++ b/misc/rake-compiler-make-install-patch.rb
@@ -1,0 +1,153 @@
+require 'rake/baseextensiontask'
+
+module Rake
+  class ExtensionTask < BaseExtensionTask
+
+    # Replace method
+    undef define_compile_tasks
+
+    def define_compile_tasks(for_platform = nil, ruby_ver = RUBY_VERSION)
+      # platform usage
+      platf = for_platform || platform
+
+      binary_path = binary(platf)
+
+      # lib_path
+      lib_path = lib_dir
+
+      lib_binary_path = "#{lib_path}/#{binary_path}"
+      lib_binary_dir_path = File.dirname(lib_binary_path)
+
+      # tmp_path
+      tmp_path = "#{@tmp_dir}/#{platf}/#{@name}/#{ruby_ver}"
+      stage_path = "#{@tmp_dir}/#{platf}/stage"
+
+      siteconf_path = "#{tmp_path}/.rake-compiler-siteconf.rb"
+      tmp_binary_path = "#{tmp_path}/#{binary_path}"
+      tmp_binary_dir_path = File.dirname(tmp_binary_path)
+      stage_binary_path = "#{stage_path}/#{lib_path}/#{binary_path}"
+      stage_binary_dir_path = File.dirname(stage_binary_path)
+
+      # cleanup and clobbering
+      CLEAN.include(tmp_path)
+      CLEAN.include(stage_path)
+      CLOBBER.include("#{lib_path}/#{binary(platf)}")
+      CLOBBER.include("#{@tmp_dir}")
+
+      # directories we need
+      directory tmp_path
+      directory tmp_binary_dir_path
+      directory lib_binary_dir_path
+      directory stage_binary_dir_path
+
+      directory File.dirname(siteconf_path)
+      # Set paths for "make install" destinations
+      file siteconf_path => File.dirname(siteconf_path) do
+        File.open(siteconf_path, "w") do |siteconf|
+          siteconf.puts "require 'rbconfig'"
+          siteconf.puts "require 'mkmf'"
+          siteconf.puts "dest_path = mkintpath(#{File.expand_path(lib_path).dump})"
+          %w[sitearchdir sitelibdir].each do |dir|
+            siteconf.puts "RbConfig::MAKEFILE_CONFIG['#{dir}'] = dest_path"
+            siteconf.puts "RbConfig::CONFIG['#{dir}'] = dest_path"
+          end
+        end
+      end
+
+      # copy binary from temporary location to final lib
+      # tmp/extension_name/extension_name.{so,bundle} => lib/
+      task "copy:#{@name}:#{platf}:#{ruby_ver}" => [lib_binary_dir_path, tmp_binary_path, "#{tmp_path}/Makefile"] do
+        # install in lib for native platform only
+        unless for_platform
+          sh "#{make} install", chdir: tmp_path
+        end
+      end
+      # copy binary from temporary location to staging directory
+      task "copy:#{@name}:#{platf}:#{ruby_ver}" => [stage_binary_dir_path, tmp_binary_path] do
+        cp tmp_binary_path, stage_binary_path
+      end
+
+      # copy other gem files to staging directory
+      define_staging_file_tasks(@gem_spec.files, lib_path, stage_path, platf, ruby_ver) if @gem_spec
+
+      # binary in temporary folder depends on makefile and source files
+      # tmp/extension_name/extension_name.{so,bundle}
+      file tmp_binary_path => [tmp_binary_dir_path, "#{tmp_path}/Makefile"] + source_files do
+        jruby_compile_msg = <<-EOF
+Compiling a native C extension on JRuby. This is discouraged and a
+Java extension should be preferred.
+        EOF
+        warn_once(jruby_compile_msg) if defined?(JRUBY_VERSION)
+
+        chdir tmp_path do
+          sh make
+          if binary_path != File.basename(binary_path)
+            cp File.basename(binary_path), binary_path
+          end
+        end
+      end
+
+      # makefile depends of tmp_dir and config_script
+      # tmp/extension_name/Makefile
+      file "#{tmp_path}/Makefile" => [tmp_path, extconf, siteconf_path] do |t|
+        options = @config_options.dup
+
+        # include current directory
+        include_dirs = ['.'].concat(@config_includes).uniq.join(File::PATH_SEPARATOR)
+        cmd = [Gem.ruby, "-I#{include_dirs}", "-r#{File.basename(siteconf_path)}"]
+
+        # build a relative path to extconf script
+        abs_tmp_path = (Pathname.new(Dir.pwd) + tmp_path).realpath
+        abs_extconf = (Pathname.new(Dir.pwd) + extconf).realpath
+
+        # now add the extconf script
+        cmd << abs_extconf.relative_path_from(abs_tmp_path)
+
+        # fake.rb will be present if we are cross compiling
+        if t.prerequisites.include?("#{tmp_path}/fake.rb") then
+          options.push(*cross_config_options(platf))
+        end
+
+        # add options to command
+        cmd.push(*options)
+
+        # add any extra command line options
+        unless extra_options.empty?
+          cmd.push(*extra_options)
+        end
+
+        chdir tmp_path do
+          # FIXME: Rake is broken for multiple arguments system() calls.
+          # Add current directory to the search path of Ruby
+          sh cmd.join(' ')
+        end
+      end
+
+      # compile tasks
+      unless Rake::Task.task_defined?('compile') then
+        desc "Compile all the extensions"
+        task "compile"
+      end
+
+      # compile:name
+      unless Rake::Task.task_defined?("compile:#{@name}") then
+        desc "Compile #{@name}"
+        task "compile:#{@name}"
+      end
+
+      # Allow segmented compilation by platform (open door for 'cross compile')
+      task "compile:#{@name}:#{platf}" => ["copy:#{@name}:#{platf}:#{ruby_ver}"]
+      task "compile:#{platf}" => ["compile:#{@name}:#{platf}"]
+
+      # Only add this extension to the compile chain if current
+      # platform matches the indicated one.
+      if platf == RUBY_PLATFORM then
+        # ensure file is always copied
+        file "#{lib_path}/#{binary_path}" => ["copy:#{name}:#{platf}:#{ruby_ver}"]
+
+        task "compile:#{@name}" => ["compile:#{@name}:#{platf}"]
+        task "compile" => ["compile:#{platf}"]
+      end
+    end
+  end
+end

--- a/spec/pg_spec.rb
+++ b/spec/pg_spec.rb
@@ -46,5 +46,8 @@ describe PG do
 		        ])
 	end
 
-end
+	it "tells about the libpq library path" do
+		expect( PG::POSTGRESQL_LIB_PATH ).to include("/")
+	end
 
+end


### PR DESCRIPTION
In ELF based systems the libpq path is stored as rpath in `pg_ext.so`, so that libpq is found, even if it's not in the library search paths.

On Windows however the rpath mechanism doesn't work and the search path for libpq had to be set added manually per `RUBY_DLL_PATH`. This is now automatically done per `RubyInstaller::Runtime.add_dll_directory`.

The libpq path is available in `extconf.rb` while build only (while gem install), so that we have to pass the string to lib/pg.rb where pg_ext.so is loaded (while `require 'pg'`). This is a bit tricky, since `pg_ext.so` is linked to libpq, so that the library search path has to be set first, prior to loading `pg_ext.so`.
Therefore a second file is needed bypassing `pg_ext.so`. That is `postgresql_lib_path.rb` and it is passed by mkmf's `$INSTALLFILES` mechanism.

There's an issue with rake-compiler, which (in contrast to gem install) doesn't copy `postgresql_lib_path.rb`.
This is addressed in the second commit. Another approach would be to add a second extension file, but that is more complicated.

Fixes #365

