### PR TITLE
Add Github Actions for tests of source gem and binary gems

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -28,24 +28,9 @@ test_script:
 environment:
   matrix:
     - ruby_version: "head"
-      RUBYDOWNLOAD: x64
-      PGVERSION: 13.2-1-windows-x64
-      PGVER: 13
-    - ruby_version: "head"
       RUBYDOWNLOAD: x86
-      PGVERSION: 10.16-1-windows
-      PGVER: 10
-    - ruby_version: "30-x64"
-      PGVERSION: 11.11-1-windows-x64
-      PGVER: 11
-    - ruby_version: "30"
       PGVERSION: 10.16-1-windows
       PGVER: 10
     - ruby_version: "24"
       PGVERSION: 9.3.25-1-windows
       PGVER: 9.3
-    - ruby_version: "24-x64"
-      PGVER: 9.6
-matrix:
-  allow_failures:
-    - ruby_version: "head"

--- a/.github/workflows/binary-gems.yml
+++ b/.github/workflows/binary-gems.yml
@@ -1,0 +1,80 @@
+name: Build and test binary gems
+
+on: [push, pull_request]
+
+jobs:
+  job_build_x64:
+    name: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.0"
+      - run: bundle install
+
+      - name: Create a dummy cert to satisfy the build
+        run: |
+          mkdir -p ~/.gem/
+          ruby -ropenssl -e "puts OpenSSL::PKey::RSA.new(2048).to_pem" > ~/.gem/gem-private_key.pem
+          gem cert --build travis-ci@dummy.org --private-key ~/.gem/gem-private_key.pem
+          cp gem-public_cert.pem ~/.gem/gem-public_cert.pem
+
+      - name: Build binary gem
+        run: bundle exec rake gem:windows:x64-mingw32
+
+      - name: Upload binary gem
+        uses: actions/upload-artifact@v2
+        with:
+          name: binary-gem
+          path: pkg/*.gem
+
+  job_test_binary:
+    name: Test on Windows
+    needs: job_build_x64
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - ruby: "3.0"
+            PGVERSION: 13.2-1-windows-x64
+            PGVER: "13"
+          - ruby: "2.4"
+            PGVERSION: 10.16-1-windows
+            PGVER: "10"
+
+    runs-on: windows-latest
+    env:
+      PGVERSION: ${{ matrix.PGVERSION }}
+      PGVER: ${{ matrix.PGVER }}
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+
+      - name: Download gem from build job
+        uses: actions/download-artifact@v2
+        with:
+          name: binary-gem
+
+      - name: Download PostgreSQL
+        run: |
+          Add-Type -AssemblyName System.IO.Compression.FileSystem
+          function Unzip {
+              param([string]$zipfile, [string]$outpath)
+              [System.IO.Compression.ZipFile]::ExtractToDirectory($zipfile, $outpath)
+          }
+
+          $(new-object net.webclient).DownloadFile("http://get.enterprisedb.com/postgresql/postgresql-$env:PGVERSION-binaries.zip", "postgresql-binaries.zip")
+          Unzip "postgresql-binaries.zip" "."
+          echo "$pwd/pgsql/bin"  | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+          echo "PGUSER=$env:USERNAME"  | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          echo "PGPASSWORD="  | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+
+      - run: bundle install
+      - run: gem install --local *.gem --verbose
+      - name: Run specs
+        run: ruby -rpg -S rspec spec/**/*_spec.rb

--- a/.github/workflows/source-gem.yml
+++ b/.github/workflows/source-gem.yml
@@ -1,0 +1,117 @@
+name: Build and test source gem
+
+on: [push, pull_request]
+
+jobs:
+  job_build_gem:
+    name: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.0"
+
+      - name: Build source gem
+        run: gem build pg.gemspec
+
+      - name: Upload source gem
+        uses: actions/upload-artifact@v2
+        with:
+          name: source-gem
+          path: "*.gem"
+
+  job_test_gem:
+    name: Test built gem
+    needs: job_build_gem
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: windows
+            ruby: "head"
+            PGVERSION: 13.2-1-windows-x64
+            PGVER: "13"
+          - os: windows
+            ruby: "2.4"
+            PGVERSION: 9.3.25-1-windows-x64
+            PGVER: "9.3"
+          - os: ubuntu
+            ruby: "head"
+            PGVER: "13"
+          - os: ubuntu
+            ruby: "2.2"
+            PGVER: "9.3"
+          - os: ubuntu
+            ruby: "truffleruby"
+            PGVER: "13"
+          - os: ubuntu
+            ruby: "truffleruby-head"
+            PGVER: "13"
+          - os: macos
+            ruby: "head"
+            PGVERSION: 13.2-1-osx
+            PGVER: "13"
+
+    runs-on: ${{ matrix.os }}-latest
+    env:
+      PGVERSION: ${{ matrix.PGVERSION }}
+      PGVER: ${{ matrix.PGVER }}
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+
+      - name: Download gem from build job
+        uses: actions/download-artifact@v2
+        with:
+          name: source-gem
+
+      - name: Download PostgreSQL
+        if: matrix.os == 'windows'
+        run: |
+          Add-Type -AssemblyName System.IO.Compression.FileSystem
+          function Unzip {
+              param([string]$zipfile, [string]$outpath)
+              [System.IO.Compression.ZipFile]::ExtractToDirectory($zipfile, $outpath)
+          }
+
+          $(new-object net.webclient).DownloadFile("http://get.enterprisedb.com/postgresql/postgresql-$env:PGVERSION-binaries.zip", "postgresql-binaries.zip")
+          Unzip "postgresql-binaries.zip" "."
+          echo "$pwd/pgsql/bin"  | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+          echo "PGUSER=$env:USERNAME"  | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          echo "PGPASSWORD="  | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+
+      - name: Download PostgreSQL
+        if: matrix.os == 'ubuntu'
+        run: |
+          echo "deb http://apt.postgresql.org/pub/repos/apt/ focal-pgdg main $PGVER" | sudo tee -a /etc/apt/sources.list.d/pgdg.list
+          wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
+          sudo apt -y update
+          sudo apt -y --allow-downgrades install postgresql-$PGVER libpq5=$PGVER* libpq-dev=$PGVER*
+          echo /usr/lib/postgresql/$PGVER/bin >> $GITHUB_PATH
+
+      - name: Download PostgreSQL
+        if: matrix.os == 'macos'
+        run: |
+          wget https://get.enterprisedb.com/postgresql/postgresql-$PGVERSION-binaries.zip && \
+          unzip postgresql-$PGVERSION-binaries.zip && \
+          echo `pwd`/pgsql/bin >> $GITHUB_PATH
+
+      - run: bundle install
+
+      - run: gem install --local *.gem --verbose
+      - name: Run specs
+        run: ruby -rpg -S rspec spec/**/*_spec.rb
+
+      - name: Print logs if job failed
+        if: ${{ failure() && matrix.os == 'windows' }}
+        run: ridk exec cat tmp_test_specs/*.log
+
+      - name: Print logs if job failed
+        if: ${{ failure() && matrix.os != 'windows' }}
+        run: cat tmp_test_specs/*.log

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,34 +20,12 @@ matrix:
     - rvm: "2.2"
       env:
         - "PGVERSION=9.3"
-    - rvm: "3.0"
-      env:
-        - "PGVERSION=13"
     - rvm: ruby-head
       env:
         - "PGVERSION=11"
 
-    - rvm: truffleruby
-      env:
-        - "PGVERSION=11"
-
-    - rvm: truffleruby-head
-      env:
-        - "PGVERSION=13"
-
-    - name: gem-windows
-      rvm: "3.0"
-      before_install:
-        - bundle install
-        # Create a dummy cert to satisfy the build
-        - ruby -ropenssl -e "puts OpenSSL::PKey::RSA.new(2048).to_pem" > ~/.gem/gem-private_key.pem
-        - gem cert --build travis-ci@dummy.org --private-key ~/.gem/gem-private_key.pem
-        - cp gem-public_cert.pem ~/.gem/gem-public_cert.pem
-      script:
-        - rake gem:windows:x86-mingw32
   allow_failures:
     - rvm: ruby-head
-    - rvm: truffleruby-head
   fast_finish: true
 
 before_install:

--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ source "https://rubygems.org/"
 gem "hoe-mercurial", "~>1.4", :group => [:development, :test]
 gem "hoe-deveiate", "~>0.9", :group => [:development, :test]
 gem "hoe-highline", "~>0.2", :group => [:development, :test]
-gem "rake-compiler", "~>1.0", :group => [:development, :test]
+gem "rake-compiler", "1.1.1", :group => [:development, :test]
 gem "rake-compiler-dock", "~>1.0", :group => [:development, :test]
 gem "hoe-bundler", "~>1.0", :group => [:development, :test]
 gem "rspec", "~>3.5", :group => [:development, :test]

--- a/Rakefile
+++ b/Rakefile
@@ -6,6 +6,7 @@ require 'tmpdir'
 
 begin
 	require 'rake/extensiontask'
+	require_relative 'misc/rake-compiler-make-install-patch'
 rescue LoadError
 	abort "This Rakefile requires rake-compiler (gem install rake-compiler)"
 end
@@ -63,7 +64,7 @@ $hoespec = Hoe.spec 'pg' do
 	self.developer 'Michael Granger', 'ged@FaerieMUD.org'
 	self.developer 'Lars Kanis', 'lars@greiz-reinsdorf.de'
 
-	self.dependency 'rake-compiler', '~> 1.0', :developer
+	self.dependency 'rake-compiler', '1.1.1', :developer
 	self.dependency 'rake-compiler-dock', ['~> 1.0'], :developer
 	self.dependency 'hoe-deveiate', '~> 0.9', :developer
 	self.dependency 'hoe-bundler', '~> 1.0', :developer

--- a/Rakefile
+++ b/Rakefile
@@ -37,6 +37,7 @@ CLOBBER.include( TESTDIR.to_s )
 CLEAN.include( PKGDIR.to_s, TMPDIR.to_s )
 CLEAN.include "lib/*/libpq.dll"
 CLEAN.include "lib/pg_ext.*"
+CLEAN.include "lib/pg/postgresql_lib_path.rb"
 
 # Set up Hoe plugins
 Hoe.plugin :mercurial

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -19,7 +19,6 @@ install:
         $(new-object net.webclient).DownloadFile('http://get.enterprisedb.com/postgresql/postgresql-' + $env:PGVERSION + '.exe', 'C:/postgresql-setup.exe')
         cmd /c "C:/postgresql-setup.exe" --mode unattended --extract-only 1
       }
-      $env:RUBY_DLL_PATH = 'C:/Program Files/PostgreSQL/' + $env:PGVER + '/bin;C:/Program Files (x86)/PostgreSQL/' + $env:PGVER + '/bin'
       $env:PATH = 'C:/Program Files/PostgreSQL/' + $env:PGVER + '/bin;' + $env:PATH
       $env:PATH = 'C:/Program Files (x86)/PostgreSQL/' + $env:PGVER + '/bin;' + $env:PATH
 build_script:

--- a/misc/rake-compiler-make-install-patch.rb
+++ b/misc/rake-compiler-make-install-patch.rb
@@ -1,0 +1,153 @@
+require 'rake/baseextensiontask'
+
+module Rake
+  class ExtensionTask < BaseExtensionTask
+
+    # Replace method
+    undef define_compile_tasks
+
+    def define_compile_tasks(for_platform = nil, ruby_ver = RUBY_VERSION)
+      # platform usage
+      platf = for_platform || platform
+
+      binary_path = binary(platf)
+
+      # lib_path
+      lib_path = lib_dir
+
+      lib_binary_path = "#{lib_path}/#{binary_path}"
+      lib_binary_dir_path = File.dirname(lib_binary_path)
+
+      # tmp_path
+      tmp_path = "#{@tmp_dir}/#{platf}/#{@name}/#{ruby_ver}"
+      stage_path = "#{@tmp_dir}/#{platf}/stage"
+
+      siteconf_path = "#{tmp_path}/.rake-compiler-siteconf.rb"
+      tmp_binary_path = "#{tmp_path}/#{binary_path}"
+      tmp_binary_dir_path = File.dirname(tmp_binary_path)
+      stage_binary_path = "#{stage_path}/#{lib_path}/#{binary_path}"
+      stage_binary_dir_path = File.dirname(stage_binary_path)
+
+      # cleanup and clobbering
+      CLEAN.include(tmp_path)
+      CLEAN.include(stage_path)
+      CLOBBER.include("#{lib_path}/#{binary(platf)}")
+      CLOBBER.include("#{@tmp_dir}")
+
+      # directories we need
+      directory tmp_path
+      directory tmp_binary_dir_path
+      directory lib_binary_dir_path
+      directory stage_binary_dir_path
+
+      directory File.dirname(siteconf_path)
+      # Set paths for "make install" destinations
+      file siteconf_path => File.dirname(siteconf_path) do
+        File.open(siteconf_path, "w") do |siteconf|
+          siteconf.puts "require 'rbconfig'"
+          siteconf.puts "require 'mkmf'"
+          siteconf.puts "dest_path = mkintpath(#{File.expand_path(lib_path).dump})"
+          %w[sitearchdir sitelibdir].each do |dir|
+            siteconf.puts "RbConfig::MAKEFILE_CONFIG['#{dir}'] = dest_path"
+            siteconf.puts "RbConfig::CONFIG['#{dir}'] = dest_path"
+          end
+        end
+      end
+
+      # copy binary from temporary location to final lib
+      # tmp/extension_name/extension_name.{so,bundle} => lib/
+      task "copy:#{@name}:#{platf}:#{ruby_ver}" => [lib_binary_dir_path, tmp_binary_path, "#{tmp_path}/Makefile"] do
+        # install in lib for native platform only
+        unless for_platform
+          sh "#{make} install", chdir: tmp_path
+        end
+      end
+      # copy binary from temporary location to staging directory
+      task "copy:#{@name}:#{platf}:#{ruby_ver}" => [stage_binary_dir_path, tmp_binary_path] do
+        cp tmp_binary_path, stage_binary_path
+      end
+
+      # copy other gem files to staging directory
+      define_staging_file_tasks(@gem_spec.files, lib_path, stage_path, platf, ruby_ver) if @gem_spec
+
+      # binary in temporary folder depends on makefile and source files
+      # tmp/extension_name/extension_name.{so,bundle}
+      file tmp_binary_path => [tmp_binary_dir_path, "#{tmp_path}/Makefile"] + source_files do
+        jruby_compile_msg = <<-EOF
+Compiling a native C extension on JRuby. This is discouraged and a
+Java extension should be preferred.
+        EOF
+        warn_once(jruby_compile_msg) if defined?(JRUBY_VERSION)
+
+        chdir tmp_path do
+          sh make
+          if binary_path != File.basename(binary_path)
+            cp File.basename(binary_path), binary_path
+          end
+        end
+      end
+
+      # makefile depends of tmp_dir and config_script
+      # tmp/extension_name/Makefile
+      file "#{tmp_path}/Makefile" => [tmp_path, extconf, siteconf_path] do |t|
+        options = @config_options.dup
+
+        # include current directory
+        include_dirs = ['.'].concat(@config_includes).uniq.join(File::PATH_SEPARATOR)
+        cmd = [Gem.ruby, "-I#{include_dirs}", "-r#{File.basename(siteconf_path)}"]
+
+        # build a relative path to extconf script
+        abs_tmp_path = (Pathname.new(Dir.pwd) + tmp_path).realpath
+        abs_extconf = (Pathname.new(Dir.pwd) + extconf).realpath
+
+        # now add the extconf script
+        cmd << abs_extconf.relative_path_from(abs_tmp_path)
+
+        # fake.rb will be present if we are cross compiling
+        if t.prerequisites.include?("#{tmp_path}/fake.rb") then
+          options.push(*cross_config_options(platf))
+        end
+
+        # add options to command
+        cmd.push(*options)
+
+        # add any extra command line options
+        unless extra_options.empty?
+          cmd.push(*extra_options)
+        end
+
+        chdir tmp_path do
+          # FIXME: Rake is broken for multiple arguments system() calls.
+          # Add current directory to the search path of Ruby
+          sh cmd.join(' ')
+        end
+      end
+
+      # compile tasks
+      unless Rake::Task.task_defined?('compile') then
+        desc "Compile all the extensions"
+        task "compile"
+      end
+
+      # compile:name
+      unless Rake::Task.task_defined?("compile:#{@name}") then
+        desc "Compile #{@name}"
+        task "compile:#{@name}"
+      end
+
+      # Allow segmented compilation by platform (open door for 'cross compile')
+      task "compile:#{@name}:#{platf}" => ["copy:#{@name}:#{platf}:#{ruby_ver}"]
+      task "compile:#{platf}" => ["compile:#{@name}:#{platf}"]
+
+      # Only add this extension to the compile chain if current
+      # platform matches the indicated one.
+      if platf == RUBY_PLATFORM then
+        # ensure file is always copied
+        file "#{lib_path}/#{binary_path}" => ["copy:#{name}:#{platf}:#{ruby_ver}"]
+
+        task "compile:#{@name}" => ["compile:#{@name}:#{platf}"]
+        task "compile" => ["compile:#{platf}"]
+      end
+    end
+  end
+end

--- a/spec/pg_spec.rb
+++ b/spec/pg_spec.rb
@@ -46,5 +46,8 @@ describe PG do
 		        ])
 	end
 
-end
+	it "tells about the libpq library path" do
+		expect( PG::POSTGRESQL_LIB_PATH ).to include("/")
+	end
 
+end


### PR DESCRIPTION
That way we can finally test if our binary windows gems run properly and if gem packaging works.
And this adds a run on Macos.

Also remove no longer necessary jobs from Appveyor and Travis-CI.

The first two commits are from #373. They allow to do Windows tests without setting `RUBY_DLL_PATH`.

Fixes #362
