### PR TITLE
Improve performance of type map creation

### DIFF
--- a/lib/pg/basic_type_mapping.rb
+++ b/lib/pg/basic_type_mapping.rb
@@ -87,8 +87,6 @@ module PG::BasicTypeRegistry
 		end
 	end
 
-	private
-
 	def build_coder_maps(connection)
 		result = connection.exec(<<-SQL).to_a
 			SELECT t.oid, t.typname, t.typelem, t.typdelim, ti.proname AS typinput
@@ -107,6 +105,7 @@ module PG::BasicTypeRegistry
 			h
 		end
 	end
+	module_function :build_coder_maps
 
 	ValidFormats = { 0 => true, 1 => true }
 	ValidDirections = { :encoder => true, :decoder => true }
@@ -121,8 +120,6 @@ module PG::BasicTypeRegistry
 	# encoder_map is then dynamically built with oids as the key and Type
 	# objects as values.
 	CODERS_BY_NAME = []
-
-	public
 
 	# Register an encoder or decoder instance for casting a PostgreSQL type.
 	#
@@ -290,8 +287,8 @@ class PG::BasicTypeMapForResults < PG::TypeMapByOid
 		end
 	end
 
-	def initialize(connection)
-		@coder_maps = build_coder_maps(connection)
+	def initialize(connection, coder_maps: nil)
+		@coder_maps = coder_maps || build_coder_maps(connection)
 
 		# Populate TypeMapByOid hash with decoders
 		@coder_maps.flat_map{|f| f[:decoder].coders }.each do |coder|
@@ -382,8 +379,8 @@ class PG::BasicTypeMapForQueries < PG::TypeMapByClass
 
 	include PG::BasicTypeRegistry
 
-	def initialize(connection)
-		@coder_maps = build_coder_maps(connection)
+	def initialize(connection, coder_maps: nil)
+		@coder_maps = coder_maps || build_coder_maps(connection)
 		@array_encoders_by_klass = array_encoders_by_klass
 		@encode_array_as = :array
 		init_encoders

--- a/lib/pg/basic_type_mapping.rb
+++ b/lib/pg/basic_type_mapping.rb
@@ -89,25 +89,12 @@ module PG::BasicTypeRegistry
 
 	private
 
-	def supports_ranges?(connection)
-		connection.server_version >= 90200
-	end
-
 	def build_coder_maps(connection)
-		if supports_ranges?(connection)
-			result = connection.exec <<-SQL
-				SELECT t.oid, t.typname, t.typelem, t.typdelim, ti.proname AS typinput, r.rngsubtype
-				FROM pg_type as t
-				JOIN pg_proc as ti ON ti.oid = t.typinput
-				LEFT JOIN pg_range as r ON t.oid = r.rngtypid
-			SQL
-		else
-			result = connection.exec <<-SQL
-				SELECT t.oid, t.typname, t.typelem, t.typdelim, ti.proname AS typinput
-				FROM pg_type as t
-				JOIN pg_proc as ti ON ti.oid = t.typinput
-			SQL
-		end
+		result = connection.exec <<-SQL
+			SELECT t.oid, t.typname, t.typelem, t.typdelim, ti.proname AS typinput
+			FROM pg_type as t
+			JOIN pg_proc as ti ON ti.oid = t.typinput
+		SQL
 
 		[
 			[0, :encoder, PG::TextEncoder::Array],

--- a/lib/pg/basic_type_mapping.rb
+++ b/lib/pg/basic_type_mapping.rb
@@ -90,7 +90,7 @@ module PG::BasicTypeRegistry
 	private
 
 	def build_coder_maps(connection)
-		result = connection.exec <<-SQL
+		result = connection.exec(<<-SQL).to_a
 			SELECT t.oid, t.typname, t.typelem, t.typdelim, ti.proname AS typinput
 			FROM pg_type as t
 			JOIN pg_proc as ti ON ti.oid = t.typinput

--- a/spec/pg/basic_type_mapping_spec.rb
+++ b/spec/pg/basic_type_mapping_spec.rb
@@ -635,4 +635,12 @@ describe 'Basic type mapping' do
 			end
 		end
 	end
+
+	describe PG::BasicTypeRegistry do
+		it "can build coder maps" do
+			expect do
+				described_class.build_coder_maps(@conn)
+			end.to_not raise_error
+		end
+	end
 end


### PR DESCRIPTION
Please see individual commits for extensive details. I’m happy to separate into multiple PRs if some work needs more vetting or discussion, as each commit can stand on its own (but separating will require resolving conflicts as commits 2 & 3 both depend on 1).

This is the result of investigation after encountering some performance issues with type map initialization being unexpectedly slow (after implementing a more time-sensitive use case) when the number of rows queries from `pg_type` is quite large (~131k in production). The enclosed performance testing was done on in an ideal (and faster) development environment with similar schema and slightly large pg_type set (~189k). In our production environment we were seeing type map creation take 4,102±550 ms, and since we create two type maps, that time doubles currently. Needless to say, that is quite slow and these changes aim to improve that.

Finally, I am curious if it is possible to reduce the number of rows which are actually used to generate the coder maps, but I’m not certain if all of there are truly needed. It appears that every table with an array column gets two rows (one array_in, one record_in); since we have many tables this ends up summing to quite a lot.