### PR TITLE
Add dsize functions to typed data and use a ruby macro for default dfree

### DIFF
--- a/ext/pg.h
+++ b/ext/pg.h
@@ -315,6 +315,7 @@ VALUE pg_obj_to_i                                      _(( VALUE ));
 VALUE pg_tmbc_allocate                                 _(( void ));
 void pg_coder_init_encoder                             _(( VALUE ));
 void pg_coder_init_decoder                             _(( VALUE ));
+void pg_coder_mark 																		 _(( t_pg_coder * ));
 void pg_coder_compact                                  _(( t_pg_coder * ));
 char *pg_rb_str_ensure_capa                            _(( VALUE, long, char *, char ** ));
 
@@ -336,6 +337,7 @@ VALUE pg_typemap_result_value                          _(( t_typemap *, VALUE, i
 t_pg_coder *pg_typemap_typecast_query_param            _(( t_typemap *, VALUE, int ));
 VALUE pg_typemap_typecast_copy_get                     _(( t_typemap *, VALUE, int, int, int ));
 void pg_typemap_mark                                   _(( t_typemap * ));
+size_t pg_typemap_memsize                              _(( t_typemap * ));
 void pg_typemap_compact                                _(( t_typemap * ));
 
 PGconn *pg_get_pgconn                                  _(( VALUE ));

--- a/ext/pg_coder.c
+++ b/ext/pg_coder.c
@@ -62,6 +62,30 @@ pg_coder_init_decoder( VALUE self )
 }
 
 void
+pg_coder_mark(t_pg_coder *this)
+{
+	rb_gc_mark_movable(this->coder_obj);
+}
+
+static void
+pg_composite_coder_mark(t_pg_composite_coder *this)
+{
+  pg_coder_mark(&this->comp);
+}
+
+static size_t
+pg_coder_memsize(t_pg_coder *this)
+{
+	return sizeof(*this);
+}
+
+static size_t
+pg_composite_coder_memsize(t_pg_composite_coder *this)
+{
+	return sizeof(*this);
+}
+
+void
 pg_coder_compact(t_pg_coder *this)
 {
 	pg_gc_location(this->coder_obj);
@@ -76,9 +100,9 @@ pg_composite_coder_compact(t_pg_composite_coder *this)
 const rb_data_type_t pg_coder_type = {
 	"PG::Coder",
 	{
-		(void (*)(void*))NULL,
-		(void (*)(void*))-1,
-		(size_t (*)(const void *))NULL,
+		(void (*)(void*))pg_coder_mark,
+		RUBY_TYPED_DEFAULT_FREE,
+		(size_t (*)(const void *))pg_coder_memsize,
 		pg_compact_callback(pg_coder_compact),
 	},
 	0,
@@ -98,9 +122,9 @@ pg_simple_encoder_allocate( VALUE klass )
 static const rb_data_type_t pg_composite_coder_type = {
 	"PG::CompositeCoder",
 	{
-		(void (*)(void*))NULL,
-		(void (*)(void*))-1,
-		(size_t (*)(const void *))NULL,
+		(void (*)(void*))pg_composite_coder_mark,
+		RUBY_TYPED_DEFAULT_FREE,
+		(size_t (*)(const void *))pg_composite_coder_memsize,
 		pg_compact_callback(pg_composite_coder_compact),
 	},
 	&pg_coder_type,

--- a/ext/pg_connection.c
+++ b/ext/pg_connection.c
@@ -188,12 +188,21 @@ pgconn_gc_free( t_pg_connection *this )
 	xfree(this);
 }
 
+/*
+ * GC Size function
+ */
+static size_t
+pgconn_memsize( t_pg_connection *this )
+{
+	return sizeof(*this);
+}
+
 static const rb_data_type_t pg_connection_type = {
 	"PG::Connection",
 	{
 		(void (*)(void*))pgconn_gc_mark,
 		(void (*)(void*))pgconn_gc_free,
-		(size_t (*)(const void *))NULL,
+		(size_t (*)(const void *))pgconn_memsize,
 		pg_compact_callback(pgconn_gc_compact),
 	},
 	0,

--- a/ext/pg_copy_coder.c
+++ b/ext/pg_copy_coder.c
@@ -23,8 +23,15 @@ typedef struct {
 static void
 pg_copycoder_mark( t_pg_copycoder *this )
 {
+	pg_coder_mark(&this->comp);
 	rb_gc_mark_movable(this->typemap);
 	rb_gc_mark_movable(this->null_string);
+}
+
+static size_t
+pg_copycoder_memsize( t_pg_copycoder *this )
+{
+	return sizeof(*this);
 }
 
 static void
@@ -39,8 +46,8 @@ static const rb_data_type_t pg_copycoder_type = {
 	"PG::CopyCoder",
 	{
 		(void (*)(void*))pg_copycoder_mark,
-		(void (*)(void*))-1,
-		(size_t (*)(const void *))NULL,
+		RUBY_TYPED_DEFAULT_FREE,
+		(size_t (*)(const void *))pg_copycoder_memsize,
 		pg_compact_callback(pg_copycoder_compact),
 	},
 	&pg_coder_type,

--- a/ext/pg_record_coder.c
+++ b/ext/pg_record_coder.c
@@ -18,7 +18,14 @@ typedef struct {
 static void
 pg_recordcoder_mark( t_pg_recordcoder *this )
 {
+	pg_coder_mark(&this->comp);
 	rb_gc_mark_movable(this->typemap);
+}
+
+static size_t
+pg_recordcoder_memsize( t_pg_recordcoder *this )
+{
+	return sizeof(*this);
 }
 
 static void
@@ -32,8 +39,8 @@ static const rb_data_type_t pg_recordcoder_type = {
 	"PG::RecordCoder",
 	{
 		(void (*)(void*))pg_recordcoder_mark,
-		(void (*)(void*))-1,
-		(size_t (*)(const void *))NULL,
+		RUBY_TYPED_DEFAULT_FREE,
+		(size_t (*)(const void *))pg_recordcoder_memsize,
 		pg_compact_callback(pg_recordcoder_compact),
 	},
 	&pg_coder_type,

--- a/ext/pg_type_map.c
+++ b/ext/pg_type_map.c
@@ -12,6 +12,12 @@ pg_typemap_mark( t_typemap *this )
 	rb_gc_mark_movable(this->default_typemap);
 }
 
+size_t
+pg_typemap_memsize( t_typemap *this )
+{
+	return sizeof(*this);
+}
+
 void
 pg_typemap_compact( t_typemap *this )
 {
@@ -22,8 +28,8 @@ const rb_data_type_t pg_typemap_type = {
 	"PG::TypeMap",
 	{
 		(void (*)(void*))pg_typemap_mark,
-		(void (*)(void*))-1,
-		(size_t (*)(const void *))NULL,
+		RUBY_TYPED_DEFAULT_FREE,
+		(size_t (*)(const void *))pg_typemap_memsize,
 		pg_compact_callback(pg_typemap_compact),
 	},
 	0,

--- a/ext/pg_type_map_all_strings.c
+++ b/ext/pg_type_map_all_strings.c
@@ -12,8 +12,8 @@ static const rb_data_type_t pg_tmas_type = {
 	"PG::TypeMapAllStrings",
 	{
 		(void (*)(void*))pg_typemap_mark,
-		(void (*)(void*))-1,
-		(size_t (*)(const void *))NULL,
+		RUBY_TYPED_DEFAULT_FREE,
+		(size_t (*)(const void *))pg_typemap_memsize,
 		pg_compact_callback(pg_typemap_compact),
 	},
 	&pg_typemap_type,

--- a/ext/pg_type_map_by_class.c
+++ b/ext/pg_type_map_by_class.c
@@ -123,6 +123,13 @@ pg_tmbk_mark( t_tmbk *this )
 {
 	pg_typemap_mark(&this->typemap);
 	rb_gc_mark_movable(this->klass_to_coder);
+	rb_gc_mark_movable(this->self);
+}
+
+static size_t
+pg_tmbk_memsize( t_tmbk *this )
+{
+	return sizeof(*this);
 }
 
 static void
@@ -142,8 +149,8 @@ static const rb_data_type_t pg_tmbk_type = {
 	"PG::TypeMapByClass",
 	{
 		(void (*)(void*))pg_tmbk_mark,
-		(void (*)(void*))-1,
-		(size_t (*)(const void *))NULL,
+		RUBY_TYPED_DEFAULT_FREE,
+		(size_t (*)(const void *))pg_tmbk_memsize,
 		pg_compact_callback(pg_tmbk_compact),
 	},
 	&pg_typemap_type,

--- a/ext/pg_type_map_by_column.c
+++ b/ext/pg_type_map_by_column.c
@@ -186,6 +186,12 @@ pg_tmbc_mark( t_tmbc *this )
 	}
 }
 
+static size_t
+pg_tmbc_memsize( t_tmbc *this )
+{
+	return sizeof(*this);
+}
+
 static void
 pg_tmbc_compact( t_tmbc *this )
 {
@@ -215,7 +221,7 @@ static const rb_data_type_t pg_tmbc_type = {
 	{
 		(void (*)(void*))pg_tmbc_mark,
 		(void (*)(void*))pg_tmbc_free,
-		(size_t (*)(const void *))NULL,
+		(size_t (*)(const void *))pg_tmbc_memsize,
 		pg_compact_callback(pg_tmbc_compact),
 	},
 	&pg_typemap_type,

--- a/ext/pg_type_map_by_mri_type.c
+++ b/ext/pg_type_map_by_mri_type.c
@@ -104,6 +104,12 @@ pg_tmbmt_mark( t_tmbmt *this )
 	FOR_EACH_MRI_TYPE( GC_MARK_AS_USED );
 }
 
+static size_t
+pg_tmbmt_memsize( t_tmbmt *this )
+{
+	return sizeof(*this);
+}
+
 #define GC_COMPACT(type) \
 	pg_gc_location( this->coders.ask_##type ); \
 	pg_gc_location( this->coders.coder_obj_##type );
@@ -119,8 +125,8 @@ static const rb_data_type_t pg_tmbmt_type = {
 	"PG::TypeMapByMriType",
 	{
 		(void (*)(void*))pg_tmbmt_mark,
-		(void (*)(void*))-1,
-		(size_t (*)(const void *))NULL,
+		RUBY_TYPED_DEFAULT_FREE,
+		(size_t (*)(const void *))pg_tmbmt_memsize,
 		pg_compact_callback(pg_tmbmt_compact),
 	},
 	&pg_typemap_type,

--- a/ext/pg_type_map_by_oid.c
+++ b/ext/pg_type_map_by_oid.c
@@ -164,6 +164,12 @@ pg_tmbo_mark( t_tmbo *this )
 	}
 }
 
+static size_t
+pg_tmbo_memsize( t_tmbo *this )
+{
+	return sizeof(*this);
+}
+
 static void
 pg_tmbo_compact( t_tmbo *this )
 {
@@ -179,8 +185,8 @@ static const rb_data_type_t pg_tmbo_type = {
 	"PG::TypeMapByOid",
 	{
 		(void (*)(void*))pg_tmbo_mark,
-		(void (*)(void*))-1,
-		(size_t (*)(const void *))NULL,
+		RUBY_TYPED_DEFAULT_FREE,
+		(size_t (*)(const void *))pg_tmbo_memsize,
 		pg_compact_callback(pg_tmbo_compact),
 	},
 	&pg_typemap_type,

--- a/ext/pg_type_map_in_ruby.c
+++ b/ext/pg_type_map_in_ruby.c
@@ -31,8 +31,8 @@ static const rb_data_type_t pg_tmir_type = {
 	"PG::TypeMapInRuby",
 	{
 		(void (*)(void*))pg_typemap_mark,
-		(void (*)(void*))-1,
-		(size_t (*)(const void *))NULL,
+		RUBY_TYPED_DEFAULT_FREE,
+		(size_t (*)(const void *))pg_typemap_memsize,
 		pg_compact_callback(pg_tmir_compact),
 	},
 	&pg_typemap_type,


### PR DESCRIPTION
This is a followup of #349

1. ruby macro for default `dfree` is used
2. added functions for `dsize`
3. added missing mark functions