### PR TITLE
Cancel a possibly running query before a transaction is rolled back

### DIFF
--- a/lib/pg/connection.rb
+++ b/lib/pg/connection.rb
@@ -225,6 +225,8 @@ class PG::Connection
 		exec "BEGIN"
 		res = yield(self)
 	rescue Exception
+		cancel if transaction_status != PG::PQTRANS_IDLE
+		block
 		exec "ROLLBACK"
 		raise
 	else


### PR DESCRIPTION
It's the intention of a transaction to rollback all queries anyway and there's no use in keeping the query running any longer.

Previously the rollback could be delayed until the latest query in the transaction finished, if the rollback was caused by a ruby exception or signal like Ctrl-C.

Fixes #390

/cc @thatsmydoing