### PR TITLE
Update CI status badges around Travis CI

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -31,9 +31,9 @@ A small example usage:
 
 == Build Status
 
-{<img src="https://travis-ci.org/ged/ruby-pg.svg?branch=master" alt="Build Status Travis-CI" />}[https://travis-ci.org/ged/ruby-pg]
-{<img src="https://ci.appveyor.com/api/projects/status/gjx5axouf3b1wicp?svg=true" alt="Build Status Appveyor" />}[https://ci.appveyor.com/project/ged/ruby-pg-9j8l3]
 {<img src="https://github.com/ged/ruby-pg/actions/workflows/source-gem.yml/badge.svg?branch=master" alt="Build Status Github Actions" />}[https://github.com/ged/ruby-pg/actions/workflows/source-gem.yml]
+{<img src="https://ci.appveyor.com/api/projects/status/gjx5axouf3b1wicp?svg=true" alt="Build Status Appveyor" />}[https://ci.appveyor.com/project/ged/ruby-pg-9j8l3]
+{<img src="https://app.travis-ci.com/larskanis/ruby-pg.svg?branch=master" alt="Build Status" />}[https://app.travis-ci.com/larskanis/ruby-pg]
 
 == Requirements
 


### PR DESCRIPTION
- Re-order CI badges:
   - from: Travis CI (.org) --> AppVeyor --> GitHub Actions
   - to: GitHub Actions --> AppVeyor --> Travis CI (.com)

Supersedes #406

Follows up #374

Signed-off-by: Takuya Noguchi <takninnovationresearch@gmail.com>