### PR TITLE
[RFC] Change clog link on README to relative path

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -2,7 +2,7 @@
 
 home :: https://github.com/ged/ruby-pg
 docs :: http://deveiate.org/code/pg
-clog :: https://github.com/ged/ruby-pg/blob/master/History.rdoc
+clog :: link:/History.rdoc
 
 {<img src="https://badges.gitter.im/Join%20Chat.svg" alt="Join the chat at https://gitter.im/ged/ruby-pg">}[https://gitter.im/ged/ruby-pg?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge]
 


### PR DESCRIPTION
I found that the link to clog file on README is broken on GitHub.
It indicates to `https://github_com/***/History_rdoc.html` instead of `https://github.com/***/History_rdoc` .

This can be fixed by changing the URL to [local file links](https://docs.ruby-lang.org/en/2.1.0/RDoc/Markup.html#class-RDoc::Markup-label-Links) on RDoc.
But I'm not sure this is the best way to handle this problem because I don't know how README is used on other places.

I would be grateful if you could give me an advice.
Thank you. 