### PR TITLE
Fix high CPU usage when waiting with a timeout on Ruby < 3.0

### DIFF
--- a/ext/pg_connection.c
+++ b/ext/pg_connection.c
@@ -2241,7 +2241,7 @@ pg_rb_thread_io_wait(VALUE io, VALUE events, VALUE timeout) {
 	GetOpenFile((io), fptr);
 	if( !NIL_P(timeout) ){
 		ptimeout.tv_sec = (time_t)(NUM2DBL(timeout));
-		ptimeout.tv_usec = (time_t)(NUM2DBL(timeout) - (double)ptimeout.tv_sec);
+		ptimeout.tv_usec = (time_t)((NUM2DBL(timeout) - (double)ptimeout.tv_sec) * 1e6);
 
 		gettimeofday(&currtime, NULL);
 		timeradd(&currtime, &ptimeout, &aborttime);
@@ -2332,7 +2332,7 @@ pg_rb_io_wait(VALUE io, VALUE events, VALUE timeout) {
 	GetOpenFile((io), fptr);
 	if( !NIL_P(timeout) ){
 		waittime.tv_sec = (time_t)(NUM2DBL(timeout));
-		waittime.tv_usec = (time_t)(NUM2DBL(timeout) - (double)waittime.tv_sec);
+		waittime.tv_usec = (time_t)((NUM2DBL(timeout) - (double)waittime.tv_sec) * 1e6);
 	}
 	res = rb_wait_for_single_fd(fptr->fd, NUM2UINT(events), NIL_P(timeout) ? NULL : &waittime);
 


### PR DESCRIPTION
This fixes a regression in pg 1.3.0 where the `pg_rb_io_wait` compatibility shim for Ruby 2.x drops fractional seconds. This results in `wait_socket_readable` waiting only whole seconds and busy-looping any remaining fractional seconds for every wait. Waits below 1000 ms will exclusively busy-loop.

This can be reproduced with the following test script:

```ruby
require 'pg'
require 'benchmark'

connection = PG::Connection.new

bm = Benchmark.measure do
  connection.wait_for_notify(1.5)
end

p bm.total.round(3)
```

The output on Ruby 2.7 will show ~0.5 seconds of CPU usage without this fix when it should be ~0.0 seconds. Ruby 3.x is unaffected.