### PR TITLE
Fix String objects with non-applied encoding

### DIFF
--- a/ext/pg_type_map_all_strings.c
+++ b/ext/pg_type_map_all_strings.c
@@ -76,6 +76,7 @@ pg_tmas_fit_to_copy_get( VALUE self )
 static VALUE
 pg_tmas_typecast_copy_get( t_typemap *p_typemap, VALUE field_str, int fieldno, int format, int enc_idx )
 {
+	rb_str_modify(field_str);
 	if( format == 0 ){
 		PG_ENCODING_SET_NOCHECK( field_str, enc_idx );
 	} else {

--- a/ext/pg_type_map_by_column.c
+++ b/ext/pg_type_map_by_column.c
@@ -150,10 +150,12 @@ pg_tmbc_typecast_copy_get( t_typemap *p_typemap, VALUE field_str, int fieldno, i
 
 	/* Is it a pure String conversion? Then we can directly send field_str to the user. */
 	if( dec_func == pg_text_dec_string ){
+		rb_str_modify(field_str);
 		PG_ENCODING_SET_NOCHECK( field_str, enc_idx );
 		return field_str;
 	}
 	if( dec_func == pg_bin_dec_bytea ){
+		rb_str_modify(field_str);
 		PG_ENCODING_SET_NOCHECK( field_str, rb_ascii8bit_encindex() );
 		return field_str;
 	}

--- a/spec/pg/type_spec.rb
+++ b/spec/pg/type_spec.rb
@@ -1015,9 +1015,10 @@ describe "PG::Type derivations" do
 					end
 
 					it 'should respect input character encoding' do
-						v = decoder.decode("Héllo\n".encode("iso-8859-1")).first
-						expect( v.encoding ).to eq(Encoding::ISO_8859_1)
-						expect( v ).to eq("Héllo".encode("iso-8859-1"))
+						v = decoder.decode("Héllo\n".encode("EUC-JP")).first
+						expect( v.encoding ).to eq(Encoding::EUC_JP)
+						expect( v ).to eq("Héllo".encode("EUC-JP"))
+						expect( v.length ).to eq(5)
 					end
 				end
 			end


### PR DESCRIPTION
The COPY and record decoders use a ruby string as internal buffer. If this buffer is given to the user, it must be passed through `rb_str_modify()`.

Fixes #427