### PR TITLE
Cancel only active query after failing transaction

### DIFF
--- a/lib/pg/connection.rb
+++ b/lib/pg/connection.rb
@@ -313,7 +313,7 @@ class PG::Connection
 		exec "BEGIN"
 		res = yield(self)
 	rescue Exception
-		cancel if transaction_status != PG::PQTRANS_IDLE
+		cancel if transaction_status == PG::PQTRANS_ACTIVE
 		block
 		exec "ROLLBACK"
 		raise


### PR DESCRIPTION
This avoids sending a cancel request if there is no active query running.

In case of a failing SQL statement, the transaction_status is PQTRANS_INERROR. The previous code sent a cancel request in this case although the query is known to be aborted.

In case of ruby code that raised an error, the transaction_status is PQTRANS_INTRANS. Also in this case there is no use of sending a cancel request.

The cancellation of queries in case of exceptions was introduced by #391 . Now we cancel more conservative, only in case of a running query.

The cancellation can cause issues with pgbouncer, which releases a connection after a SQL error was raised.
It then dispatched the cancel to the next SQL command. This change should solve this incompatibility.

Fixes #430