### PR TITLE
Remove FL_TEST and FL_SET

### DIFF
--- a/ext/pg_tuple.c
+++ b/ext/pg_tuple.c
@@ -471,10 +471,7 @@ pg_tuple_dump(VALUE self)
 	values = rb_ary_new4(this->num_fields, &this->values[0]);
 	a = rb_ary_new3(2, field_names, values);
 
-	if (FL_TEST(self, FL_EXIVAR)) {
-		rb_copy_generic_ivar(a, self);
-		FL_SET(a, FL_EXIVAR);
-	}
+        rb_copy_generic_ivar(a, self);
 
 	return a;
 }
@@ -542,10 +539,7 @@ pg_tuple_load(VALUE self, VALUE a)
 
 	RTYPEDDATA_DATA(self) = this;
 
-	if (FL_TEST(a, FL_EXIVAR)) {
-		rb_copy_generic_ivar(self, a);
-		FL_SET(self, FL_EXIVAR);
-	}
+        rb_copy_generic_ivar(self, a);
 
 	return self;
 }


### PR DESCRIPTION
Object flags are pretty internal information so we shouldn't be checking
them (if possible).  In this case, we don't need to check the status of
EXIVAR because `rb_copy_generic_ivar` will check the flag and return if
there are no ivars to copy[1] and will set the flag on the cloned object
if it did copy[2]

Just for some background, `FL_EXIVAR` flag indicates that an object has
instance variables, but only objects that are not of the type
`T_OBJECT`, `T_CLASS`, or `T_MODULE`.  This type of knowledge is really an
implementation detail, so I think C extensions should not know it or use
it.

1. https://github.com/ruby/ruby/blob/24909f5b3de10b6f0b6f9acbf44ed347ccabb7e7/variable.c#L1725-L1727
2. https://github.com/ruby/ruby/blob/24909f5b3de10b6f0b6f9acbf44ed347ccabb7e7/variable.c#L1741