### PR TITLE
Don't cache the socket-IO while connection setup

### DIFF
--- a/ext/pg_connection.c
+++ b/ext/pg_connection.c
@@ -475,9 +475,7 @@ pgconn_connect_poll(VALUE self)
 	PostgresPollingStatusType status;
 	status = gvl_PQconnectPoll(pg_get_pgconn(self));
 
-	if ( status == PGRES_POLLING_FAILED ) {
-		pgconn_close_socket_io(self);
-	}
+	pgconn_close_socket_io(self);
 
 	return INT2FIX((int)status);
 }
@@ -556,9 +554,7 @@ pgconn_reset_poll(VALUE self)
 	PostgresPollingStatusType status;
 	status = gvl_PQresetPoll(pg_get_pgconn(self));
 
-	if ( status == PGRES_POLLING_FAILED ) {
-		pgconn_close_socket_io(self);
-	}
+	pgconn_close_socket_io(self);
 
 	return INT2FIX((int)status);
 }

--- a/lib/pg/connection.rb
+++ b/lib/pg/connection.rb
@@ -612,9 +612,6 @@ class PG::Connection
 	alias async_cancel cancel
 
 	private def async_connect_or_reset(poll_meth)
-		# Now grab a reference to the underlying socket so we know when the connection is established
-		socket = socket_io
-
 		# Track the progress of the connection, waiting for the socket to become readable/writable before polling it
 		poll_status = PG::PGRES_POLLING_WRITING
 		until poll_status == PG::PGRES_POLLING_OK ||
@@ -623,11 +620,11 @@ class PG::Connection
 			# If the socket needs to read, wait 'til it becomes readable to poll again
 			case poll_status
 			when PG::PGRES_POLLING_READING
-				socket.wait_readable
+				socket_io.wait_readable
 
 			# ...and the same for when the socket needs to write
 			when PG::PGRES_POLLING_WRITING
-				socket.wait_writable
+				socket_io.wait_writable
 			end
 
 			# Check to see if it's finished or failed yet

--- a/spec/helpers/tcp_gate_scheduler.rb
+++ b/spec/helpers/tcp_gate_scheduler.rb
@@ -277,7 +277,7 @@ class TcpGateScheduler < Scheduler
 
 			# compare and store the fileno for debugging
 			if conn.observed_fd && conn.observed_fd != io.fileno
-				raise "observed fd changed: old:#{conn.observed_fd} new:#{io.fileno}"
+				puts "observed fd changed: old:#{conn.observed_fd} new:#{io.fileno}"
 			end
 			conn.observed_fd = io.fileno
 


### PR DESCRIPTION
The file_no of the socket IO can change while connecting. This can happen when alternative hosts are tried,
while GSS authentication and when falling back to unencrypted in `sslmode:prefer` . Therefore expire the socket IO at each `connect_poll` and `reset_poll` call.

Caching the IO previosly led to occasional errors kind of:
  `Errno::EBADF: Bad file descriptor`