### PR TITLE
Don't read from socket when data is pending in conn.block

### DIFF
--- a/spec/pg/connection_spec.rb
+++ b/spec/pg/connection_spec.rb
@@ -1449,15 +1449,15 @@ EOT
 		conn.finish
 	end
 
-	it "block should raise ConnectionBad for a closed connection" do
+	it "consume_input should raise ConnectionBad for a closed connection" do
 		serv = TCPServer.new( '127.0.0.1', 54320 )
 		conn = described_class.connect_start( '127.0.0.1', 54320, "", "", "me", "xxxx", "somedb" )
 		while [PG::CONNECTION_STARTED, PG::CONNECTION_MADE].include?(conn.connect_poll)
 			sleep 0.1
 		end
 		serv.close
-		expect{ conn.block }.to raise_error(PG::ConnectionBad, /server closed the connection unexpectedly/)
-		expect{ conn.block }.to raise_error(PG::ConnectionBad, /can't get socket descriptor|connection not open/)
+		expect{ conn.consume_input }.to raise_error(PG::ConnectionBad, /server closed the connection unexpectedly/)
+		expect{ conn.consume_input }.to raise_error(PG::ConnectionBad, /can't get socket descriptor|connection not open/)
 	end
 
 	it "calls the block supplied to wait_for_notify with the notify payload if it accepts " +


### PR DESCRIPTION
conn.block still reads data from the socket, but only after checking the result queue and waiting for readability first. Reading data from the socket (PQconsumeInput) takes much more time than just checking available results (PQisBusy). So doing it as a precaution to conn.block is a performance issue, now that we call block before each get_result in pg-1.3.x.

The test was introduced in commit 09bdc1644a373fb641851a28171d193af028f6a0 . It is not particular specific to conn.block, so that we can check the error class on consume_input equaly.

Fixes #442