### PR TITLE
Handle PGRES_COMMAND_OK in pgresult_stream_any

### DIFF
--- a/ext/pg_result.c
+++ b/ext/pg_result.c
@@ -1457,6 +1457,7 @@ pgresult_stream_any(VALUE self, void (*yielder)(VALUE, int, int, void*), void* d
 
 		switch( PQresultStatus(pgresult) ){
 			case PGRES_TUPLES_OK:
+			case PGRES_COMMAND_OK:
 				if( ntuples == 0 )
 					return self;
 				rb_raise( rb_eInvalidResultStatus, "PG::Result is not in single row mode");


### PR DESCRIPTION
Fixes usage when trying to stream the result of a procedure
call that returns no results.

Fixes Sequel tests when Sequel is set to stream all results.
Here's a reproducer that just uses ruby-pg without Sequel:

```ruby
require 'pg'
conn = PG::Connection.new(user: "sequel_test")
conn.exec(<<END)
CREATE TABLE posts (a INTEGER);
CREATE OR REPLACE PROCEDURE test_procedure_posts()
LANGUAGE SQL
AS $$
INSERT INTO posts VALUES (1) RETURNING *;
INSERT INTO posts VALUES (2) RETURNING *;
SELECT max(posts.a), min(posts.a) FROM posts;
$$;
END
at_exit{conn.exec("DROP PROCEDURE test_procedure_posts(); DROP TABLE posts;")}

conn.send_query("CALL test_procedure_posts();")
conn.set_single_row_mode
# Next method call fails without patch:
# no result received - possibly an intersection with another result retrieval (PG::NoResultError)
conn.get_result.stream_each do |res|
  p [__LINE__, res]
end
conn.block

conn.send_query("CALL test_procedure_posts();")
conn.set_single_row_mode
while res = conn.get_result
  p [__LINE__, res]
end
conn.block
```