### PR TITLE
Add `PG::Connection#hostaddr`

### DIFF
--- a/ext/pg_connection.c
+++ b/ext/pg_connection.c
@@ -617,6 +617,26 @@ pgconn_host(VALUE self)
 	return rb_str_new2(host);
 }
 
+/* PQhostaddr() appeared in PostgreSQL-12 together with PQresultMemorySize() */
+#if defined(HAVE_PQRESULTMEMORYSIZE)
+/*
+ * call-seq:
+ *    conn.hostaddr()
+ *
+ * Returns the server IP address of the active connection.
+ * This can be the address that a host name resolved to, or an IP address provided through the hostaddr parameter.
+ * If there is an error producing the host information (perhaps if the connection has not been fully established or there was an error), it returns an empty string.
+ *
+ */
+static VALUE
+pgconn_hostaddr(VALUE self)
+{
+	char *host = PQhostaddr(pg_get_pgconn(self));
+	if (!host) return Qnil;
+	return rb_str_new2(host);
+}
+#endif
+
 /*
  * call-seq:
  *    conn.port()
@@ -4345,6 +4365,9 @@ init_pg_connection()
 	rb_define_method(rb_cPGconn, "user", pgconn_user, 0);
 	rb_define_method(rb_cPGconn, "pass", pgconn_pass, 0);
 	rb_define_method(rb_cPGconn, "host", pgconn_host, 0);
+#if defined(HAVE_PQRESULTMEMORYSIZE)
+	rb_define_method(rb_cPGconn, "hostaddr", pgconn_hostaddr, 0);
+#endif
 	rb_define_method(rb_cPGconn, "port", pgconn_port, 0);
 	rb_define_method(rb_cPGconn, "tty", pgconn_tty, 0);
 	rb_define_method(rb_cPGconn, "conninfo", pgconn_conninfo, 0);

--- a/ext/pg_connection.c
+++ b/ext/pg_connection.c
@@ -607,7 +607,18 @@ pgconn_pass(VALUE self)
  * call-seq:
  *    conn.host()
  *
- * Returns the connected server name.
+ * Returns the server host name of the active connection.
+ * This can be a host name, an IP address, or a directory path if the connection is via Unix socket.
+ * (The path case can be distinguished because it will always be an absolute path, beginning with +/+ .)
+ *
+ * If the connection parameters specified both host and hostaddr, then +host+ will return the host information.
+ * If only hostaddr was specified, then that is returned.
+ * If multiple hosts were specified in the connection parameters, +host+ returns the host actually connected to.
+ *
+ * If there is an error producing the host information (perhaps if the connection has not been fully established or there was an error), it returns an empty string.
+ *
+ * If multiple hosts were specified in the connection parameters, it is not possible to rely on the result of +host+ until the connection is established.
+ * The status of the connection can be checked using the function Connection#status .
  */
 static VALUE
 pgconn_host(VALUE self)

--- a/spec/pg/connection_spec.rb
+++ b/spec/pg/connection_spec.rb
@@ -1241,6 +1241,26 @@ EOT
 		expect( (finish - start) ).to be_between( 0.2, 99 ).exclusive
 	end
 
+	it "can parse connection info strings kind of key=value" do
+		ar = PG::Connection.conninfo_parse("user=auser  host=somehost  port=3334 dbname=db")
+		expect( ar ).to be_kind_of( Array )
+		expect( ar.first ).to be_kind_of( Hash )
+		expect( ar.map{|a| a[:keyword] } ).to include( "dbname", "user", "password", "port" )
+		expect( ar.map{|a| a[:val] } ).to include( "auser", "somehost", "3334", "db" )
+	end
+
+	it "can parse connection info strings kind of URI" do
+		ar = PG::Connection.conninfo_parse("postgresql://auser@somehost:3334/db")
+		expect( ar ).to be_kind_of( Array )
+		expect( ar.first ).to be_kind_of( Hash )
+		expect( ar.map{|a| a[:keyword] } ).to include( "dbname", "user", "password", "port" )
+		expect( ar.map{|a| a[:val] } ).to include( "auser", "somehost", "3334", "db" )
+	end
+
+	it "can parse connection info strings with error" do
+		expect{ PG::Connection.conninfo_parse("host") }.to raise_error(PG::Error, /missing "=" after/)
+	end
+
 	it "can return the default connection options" do
 		expect( described_class.conndefaults ).to be_a( Array )
 		expect( described_class.conndefaults ).to all( be_a(Hash) )

--- a/spec/pg/connection_spec.rb
+++ b/spec/pg/connection_spec.rb
@@ -626,6 +626,10 @@ EOT
 		expect( @conn.options ).to eq( "" )
 	end
 
+	it "can retrieve hostaddr for the established connection", :postgresql_12 do
+		expect( @conn.hostaddr ).to match( /^127\.0\.0\.1$|^::1$/ )
+	end
+
 	it "can set error verbosity" do
 		old = @conn.set_error_verbosity( PG::PQERRORS_TERSE )
 		new = @conn.set_error_verbosity( old )


### PR DESCRIPTION
It is present since PostgreSQL-12.

Also improve API documentation of `conn.host` .