### PR TITLE
Handle client error after all data consumed in #copy_data for output

### DIFF
--- a/lib/pg/connection.rb
+++ b/lib/pg/connection.rb
@@ -281,7 +281,7 @@ class PG::Connection
 				end
 				while get_result
 				end
-				raise
+				raise err
 			else
 				res = get_last_result
 				if !res || res.result_status != PGRES_COMMAND_OK

--- a/lib/pg/connection.rb
+++ b/lib/pg/connection.rb
@@ -273,7 +273,11 @@ class PG::Connection
 				yield res
 			rescue Exception => err
 				cancel
-				while get_copy_data
+				begin
+					while get_copy_data
+					end
+				rescue PG::Error
+					# Ignore error in cleanup to avoid losing original exception
 				end
 				while get_result
 				end

--- a/spec/pg/connection_spec.rb
+++ b/spec/pg/connection_spec.rb
@@ -1069,6 +1069,17 @@ EOT
 		expect( @conn ).to still_be_usable
 	end
 
+	it "can handle client errors after all data is consumed in #copy_data for output" do
+		expect {
+			@conn.copy_data( "COPY (SELECT 1) TO STDOUT" ) do |res|
+				while @conn.get_copy_data
+				end
+				raise "boom"
+			end
+		}.to raise_error(RuntimeError, "boom")
+		expect( @conn ).to still_be_usable
+	end
+
 	it "can handle server errors in #copy_data for output" do
 		@conn.exec "ROLLBACK"
 		@conn.transaction do


### PR DESCRIPTION
During #copy_data for output, if an exception is raised after consuming all the
data from get_copy_data, then the subsequent cleanup triggers a "no COPY in
progress" error when it tries to call get_copy_data again, which causes the
original exception to be lost.

Fix by ignoring PG::Error during get_copy_data cleanup.