### PR TITLE
Avoid spurious keyword argument warning on Ruby 2.7

### DIFF
--- a/lib/pg.rb
+++ b/lib/pg.rb
@@ -65,8 +65,8 @@ module PG
 
 
 	### Convenience alias for PG::Connection.new.
-	def self.connect( *args, **kwargs, &block )
-		Connection.new( *args, **kwargs, &block )
+	def self.connect( *args, &block )
+		Connection.new( *args, &block )
 	end
 
 

--- a/lib/pg/connection.rb
+++ b/lib/pg/connection.rb
@@ -701,8 +701,8 @@ class PG::Connection
 		# connection will have its +client_encoding+ set accordingly.
 		#
 		# Raises a PG::Error if the connection fails.
-		def new(*args, **kwargs)
-			conn = self.connect_start(*args, **kwargs ) or
+		def new(*args)
+			conn = self.connect_start(*args) or
 				raise(PG::Error, "Unable to create a new connection")
 
 			raise(PG::ConnectionBad, conn.error_message) if conn.status == PG::CONNECTION_BAD


### PR DESCRIPTION
There is no reason to use **kwargs in either of these methods,
as connect_start doesn't handle keywords (keywords passed to it
will be treated as a positional hash).

Fixes deprecation warning when using Sequel's postgres adapter in
Ruby 2.7.