### PR TITLE
Don't flush at each put_copy_data call, but flush at get_result

### DIFF
--- a/lib/pg/connection.rb
+++ b/lib/pg/connection.rb
@@ -407,10 +407,10 @@ class PG::Connection
 	# See also #copy_data.
 	#
 	def put_copy_data(buffer, encoder=nil)
-		until sync_put_copy_data(buffer, encoder)
-			flush
+		until res=sync_put_copy_data(buffer, encoder)
+			res = flush
 		end
-		flush
+		res
 	end
 	alias async_put_copy_data put_copy_data
 

--- a/spec/pg/connection_spec.rb
+++ b/spec/pg/connection_spec.rb
@@ -984,6 +984,19 @@ EOT
 		expect( results ).to include( "1\n", "2\n" )
 	end
 
+	it "#get_result should send remaining data before waiting" do
+		str = "abcd" * 2000 + "\n"
+		@conn.exec( "CREATE TEMP TABLE copytable2 (col1 TEXT)" )
+		@conn.exec( "COPY copytable2 FROM STDOUT" )
+
+		1000.times do
+			@conn.sync_put_copy_data(str)
+		end
+		@conn.sync_put_copy_end
+		res = @conn.get_last_result
+		expect( res.result_status ).to eq( PG::PGRES_COMMAND_OK )
+	end
+
 	describe "#copy_data" do
 		it "can process #copy_data output queries" do
 			rows = []


### PR DESCRIPTION
This better mimics, what libpq does internally.

`put_copy_data` is significantly faster when it doesn't `flush` at every call. This is by a factor of 4 on Linux and 10 on Windows when sending typical per-row blocks of 60 byte.

`put_copy_end` unconditionally calls `flush` in libpq, so it is not changed here.

Also adjust `conn.block` to send all enqueued data to mimic the behavior of `get_result` in libpq. With the change to `put_copy_data`, unsent data can happen, when largs blocks are sent. In this case `get_result` should catch up on flush. This is what the newly added spec verifies.

`PQgetResult` does flushing based on it's internal states that we don't have access to. Since `conn.block` is performance critical in case of `single_row_mode`, we don't flush at every call to `conn.block`, but only when it's about to wait for IO.