### PR TITLE
Fix transaction leak on early break/return

### DIFF
--- a/lib/pg/connection.rb
+++ b/lib/pg/connection.rb
@@ -314,16 +314,20 @@ class PG::Connection
 	# and a +COMMIT+ at the end of the block, or
 	# +ROLLBACK+ if any exception occurs.
 	def transaction
+		rollback = false
 		exec "BEGIN"
 		res = yield(self)
 	rescue Exception
+		rollback = true
 		cancel if transaction_status == PG::PQTRANS_ACTIVE
 		block
 		exec "ROLLBACK"
 		raise
-	else
-		exec "COMMIT"
-		res
+	ensure
+		unless rollback
+			exec "COMMIT"
+			res
+		end
 	end
 
 	### Returns an array of Hashes with connection defaults. See ::conndefaults

--- a/spec/pg/connection_spec.rb
+++ b/spec/pg/connection_spec.rb
@@ -825,11 +825,10 @@ EOT
 			# abort the per-example transaction so we can test our own
 			@conn.exec( 'ROLLBACK' )
 
-			res = nil
 			@conn.exec( "CREATE TABLE pie ( flavor TEXT )" )
 
 			begin
-				res = @conn.transaction do
+				@conn.transaction do
 					@conn.exec( "INSERT INTO pie VALUES ('rhubarb'), ('cherry'), ('schizophrenia')" )
 					# a prior version would neither commit nor rollback when the block included an early break/return
 					break


### PR DESCRIPTION
Having a return/break inside the Connection#transaction block would cause the transaction to neither commit nor rollback after its begin, effectively causing the transaction to remain open and leak into the next calls made to the connection and generating warnings: `WARNING:  there is already a transaction in progress`.

That's because `#transaction` used `rescue/else`, and the `else` block won't get executed in case of early break/return.

Here's the problem:

```
irb(main):001:1* def transaction
irb(main):002:1*   p 'pre'
irb(main):003:1*   yield
irb(main):004:1*   p 'post'
irb(main):005:1* rescue
irb(main):006:1*   p 'rescue'
irb(main):007:1* else
irb(main):008:1*   p 'else'
irb(main):009:1* ensure
irb(main):010:1*   p 'ensure'
irb(main):011:0> end
=> :transaction
irb(main):012:1* transaction do
irb(main):013:1*   p 'in'
irb(main):014:1*   break
irb(main):015:0> end
"pre"
"in"
"ensure"
=> nil
```

Using `ensure` instead of `rescue`'s `else` fixes the problem.