### PR TITLE
Fix another ruby 2.7 keyword warning

### DIFF
--- a/lib/pg/connection.rb
+++ b/lib/pg/connection.rb
@@ -657,8 +657,8 @@ class PG::Connection
 		# connection will have its +client_encoding+ set accordingly.
 		#
 		# Raises a PG::Error if the connection fails.
-		def new(*args, **kwargs)
-			conn = connect_to_hosts(*args, **kwargs)
+		def new(*args)
+			conn = connect_to_hosts(*args)
 
 			if block_given?
 				begin


### PR DESCRIPTION
This fixes the ruby 2.7 keyword warning again, after it was
reintroduced in 6d61d3de0ba0e8dae6d3c7dc783ab282495df8bb.