### PR TITLE
Allow PG::Error to be created without arguments

### DIFF
--- a/lib/pg/exceptions.rb
+++ b/lib/pg/exceptions.rb
@@ -7,7 +7,7 @@ require 'pg' unless defined?( PG )
 module PG
 
 	class Error < StandardError
-		def initialize(msg, connection: nil, result: nil)
+		def initialize(msg=nil, connection: nil, result: nil)
 			@connection = connection
 			@result = result
 			super(msg)

--- a/spec/pg_spec.rb
+++ b/spec/pg_spec.rb
@@ -53,6 +53,10 @@ describe PG do
 		        ])
 	end
 
+	it "can be used to raise errors without text" do
+		expect{ raise PG::InvalidTextRepresentation }.to raise_error(PG::InvalidTextRepresentation)
+	end
+
 	it "tells about the libpq library path" do
 		expect( PG::POSTGRESQL_LIB_PATH ).to include("/")
 	end


### PR DESCRIPTION
Not used in our code, but some users do this and it used to work in pg<1.4.0.

Fixes #466