### PR TITLE
Extend the error message of PG::InvalidChangeOfResultFields to tell the number of fields

### DIFF
--- a/ext/pg_result.c
+++ b/ext/pg_result.c
@@ -1476,10 +1476,10 @@ pgresult_stream_any(VALUE self, void (*yielder)(VALUE, int, int, void*), void* d
 
 		pgresult = gvl_PQgetResult(pgconn);
 		if( pgresult == NULL )
-			rb_raise( rb_eNoResultError, "no result received - possibly an intersection with another result retrieval");
+			rb_raise( rb_eNoResultError, "no result received - possibly an intersection with another query");
 
 		if( nfields != PQnfields(pgresult) )
-			rb_raise( rb_eInvalidChangeOfResultFields, "number of fields must not change in single row mode");
+			rb_raise( rb_eInvalidChangeOfResultFields, "number of fields changed in single row mode from %d to %d - this is a sign for intersection with another query", nfields, PQnfields(pgresult));
 
 		this->pgresult = pgresult;
 	}

--- a/spec/pg/result_spec.rb
+++ b/spec/pg/result_spec.rb
@@ -241,6 +241,17 @@ describe PG::Result do
 				@conn.get_result.stream_each_row.to_a
 			}.to raise_error(PG::DivisionByZero)
 		end
+
+		it "raises an error if result number of rows change" do
+			@conn.send_query( "SELECT 1" )
+			@conn.set_single_row_mode
+			expect{
+				@conn.get_result.stream_each_row do
+					@conn.discard_results
+					@conn.send_query("SELECT 2,3");
+				end
+			}.to raise_error(PG::InvalidChangeOfResultFields, /from 1 to 2 /)
+		end
 	end
 
 	it "inserts nil AS NULL and return NULL as nil" do


### PR DESCRIPTION
This is related to #468