### PR TITLE
Use Encoding::BINARY for JOHAB

### DIFF
--- a/ext/pg.c
+++ b/ext/pg.c
@@ -128,26 +128,6 @@ static struct st_table *enc_pg2ruby;
 
 
 /*
- * Look up the JOHAB encoding, creating it as a dummy encoding if it's not
- * already defined.
- */
-static rb_encoding *
-pg_find_or_create_johab(void)
-{
-	static const char * const aliases[] = { "JOHAB", "Windows-1361", "CP1361" };
-	int enc_index;
-	size_t i;
-
-	for (i = 0; i < sizeof(aliases)/sizeof(aliases[0]); ++i) {
-		enc_index = rb_enc_find_index(aliases[i]);
-		if (enc_index > 0) return rb_enc_from_index(enc_index);
-	}
-
-	enc_index = rb_define_dummy_encoding(aliases[0]);
-	return rb_enc_from_index(enc_index);
-}
-
-/*
  * Return the given PostgreSQL encoding ID as an rb_encoding.
  *
  * - returns NULL if the client encoding is 'SQL_ASCII'.
@@ -186,10 +166,6 @@ pg_get_pg_encname_as_rb_encoding( const char *pg_encname )
 		if ( strcmp(pg_encname, pg_enc_pg2ruby_mapping[i][0]) == 0 )
 			return rb_enc_find( pg_enc_pg2ruby_mapping[i][1] );
 	}
-
-	/* JOHAB isn't a builtin encoding, so make up a dummy encoding if it's seen */
-	if ( strncmp(pg_encname, "JOHAB", 5) == 0 )
-		return pg_find_or_create_johab();
 
 	/* Fallthrough to ASCII-8BIT */
 	return rb_ascii8bit_encoding();

--- a/spec/pg/connection_spec.rb
+++ b/spec/pg/connection_spec.rb
@@ -1807,10 +1807,10 @@ describe PG::Connection do
 				expect( @conn.internal_encoding ).to eq( Encoding::ASCII_8BIT )
 			end
 
-			it "the connection should use JOHAB dummy encoding when it's set to JOHAB" do
+			it "the connection should use the BINARY encoding when it's set to JOHAB" do
 				@conn.set_client_encoding "JOHAB"
 				val = @conn.exec("SELECT chr(x'3391'::int)").values[0][0]
-				expect( val.encoding.name ).to eq( "JOHAB" )
+				expect( val.encoding ).to eq( Encoding::BINARY )
 				expect( val.unpack("H*")[0] ).to eq( "dc65" )
 			end
 
@@ -1875,20 +1875,6 @@ describe PG::Connection do
 				expect { @conn.set_client_encoding( "invalid" ) }.to raise_error(PG::Error, /invalid value/){|err| expect(err).to have_attributes(connection: @conn) }
 				expect { @conn.set_client_encoding( :invalid ) }.to raise_error(TypeError)
 				expect { @conn.set_client_encoding( nil ) }.to raise_error(TypeError)
-			end
-
-			it "can use an encoding with high index for client encoding" do
-				# Allocate a lot of encoding indices, so that MRI's ENCODING_INLINE_MAX is exceeded
-				unless Encoding.name_list.include?("pgtest-0")
-					256.times do |eidx|
-						Encoding::UTF_8.replicate("pgtest-#{eidx}")
-					end
-				end
-
-				# Now allocate the JOHAB encoding with an unusual high index
-				@conn.set_client_encoding "JOHAB"
-				val = @conn.exec("SELECT chr(x'3391'::int)").values[0][0]
-				expect( val.encoding.name ).to eq( "JOHAB" )
 			end
 
 		end


### PR DESCRIPTION
* A dummy encoding does not understand JOHAB anyway.
* Creating an extra encoding leads to significant complexity and slowdowns
  in Ruby implementations: https://bugs.ruby-lang.org/issues/18949