### PR TITLE
Handle multiple hosts in the connection string, where only one host h…

### DIFF
--- a/lib/pg/connection.rb
+++ b/lib/pg/connection.rb
@@ -689,7 +689,7 @@ class PG::Connection
 
 		private def connect_to_hosts(*args)
 			# If we have just one entry, and the entry is a postgres URI, pass it as is to connect_internal
-			if (args.length == 1) && (args[0] =~ %r{postgres://.+})
+			if (args.length == 1) && (args[0].is_a?(String) || arg[0].is_a?(URI)) && (args[0].to_s =~ %r{postgres://.+})
 				return connect_internal(args[0])
 			else
 				option_string = parse_connect_args(*args)

--- a/lib/pg/connection.rb
+++ b/lib/pg/connection.rb
@@ -764,6 +764,10 @@ class PG::Connection
 					# Seems to be no authentication error -> try next host
 					errors << err
 					return nil
+        elsif err.to_s =~ /.*session is read-only.*/
+          # Probably a host in a multi host connection string is read only
+          errors << err
+          return nil
 				else
 					# Probably an authentication error
 					raise

--- a/lib/pg/connection.rb
+++ b/lib/pg/connection.rb
@@ -59,13 +59,11 @@ class PG::Connection
 	# The method adds the option "fallback_application_name" if it isn't already set.
 	# It returns a connection string with "key=value" pairs.
 	def self.parse_connect_args( *args )
-		pp args
 		hash_arg = args.last.is_a?( Hash ) ? args.pop.transform_keys(&:to_sym) : {}
 		iopts = {}
 		conn_string = nil
 
 		if args.length == 1
-			pp args.first
 			case args.first
 			when URI, /=/, /:\/\//
 				# Option or URL string style
@@ -93,7 +91,6 @@ class PG::Connection
 			iopts[:fallback_application_name] = $0.sub( /^(.{30}).{4,}(.{30})$/ ){ $1+"..."+$2 }
 		end
 
-		puts "Connecting to #{conn_string}"
 		return conn_string || connect_hash_to_string(iopts)
 	end
 
@@ -122,7 +119,7 @@ class PG::Connection
 	# of blocking mode of operation, #copy_data is preferred to raw calls
 	# of #put_copy_data, #get_copy_data and #put_copy_end.
 	#
-	# _coder_ can be a PG::Coder derivatiyaml deployment manifest cloudfoundry manifest.ymlon
+	# _coder_ can be a PG::Coder derivation
 	# (typically PG::TextEncoder::CopyRow or PG::TextDecoder::CopyRow).
 	# This enables encoding of data fields given to #put_copy_data
 	# or decoding of fields received by #get_copy_data.

--- a/lib/pg/connection.rb
+++ b/lib/pg/connection.rb
@@ -61,7 +61,6 @@ class PG::Connection
 	def self.parse_connect_args( *args )
 		hash_arg = args.last.is_a?( Hash ) ? args.pop.transform_keys(&:to_sym) : {}
 		iopts = {}
-		conn_string = nil
 
 		if args.length == 1
 			case args.first
@@ -91,7 +90,7 @@ class PG::Connection
 			iopts[:fallback_application_name] = $0.sub( /^(.{30}).{4,}(.{30})$/ ){ $1+"..."+$2 }
 		end
 
-		return conn_string || connect_hash_to_string(iopts)
+		return connect_hash_to_string(iopts)
 	end
 
 	#  call-seq:
@@ -689,7 +688,7 @@ class PG::Connection
 
 		private def connect_to_hosts(*args)
 			# If we have just one entry, and the entry is a postgres URI, pass it as is to connect_internal
-			if (args.length == 1) && (args[0].is_a?(String) || arg[0].is_a?(URI)) && (args[0].to_s =~ %r{postgres://.+})
+			if (args.length == 1) && (args[0].is_a?(String) || args[0].is_a?(URI)) && (args[0].to_s =~ %r{postgres://.+})
 				return connect_internal(args[0])
 			else
 				option_string = parse_connect_args(*args)

--- a/spec/pg/connection_spec.rb
+++ b/spec/pg/connection_spec.rb
@@ -208,6 +208,15 @@ describe PG::Connection do
 				$0 = old_0
 			end
 		end
+
+		let(:uri2) { 'postgres://127.0.0.1:5432,127.0.0.2:5432/db01?target_session_attrs=read-write&sslmode=require&user=user'}
+
+		it "accepts an URI string with two hosts" do
+			string = described_class.parse_connect_args( uri2 )
+
+			expect( string ).to be_a( String )
+			expect( string ).to match( %r{^user='user' dbname='db01' host='127.0.0.1,127.0.0.2' port='5432,5432' sslmode='require' target_session_attrs='read-write' fallback_application_name} )
+		end
 	end
 
 	it "connects successfully with connection string" do


### PR DESCRIPTION
…as writable session. Will skip read-only hosts

This small change adds a test to see if the failure of the connection is because the host is read-only, and the session has a read-write requirement. 

With this change a connection string of the format: **postgres://192.168.1.20:5432,192.168.2.30:5432/liba_app?target_session_attrs=read-write&sslmode=require** will work correctly, even if the first host (192.168.1.20) is the read only host in a primary/secondary style cluster