### PR TITLE
Move PQclear to the result stream loop, to let sequel_pg use it

### DIFF
--- a/lib/pg/version.rb
+++ b/lib/pg/version.rb
@@ -1,4 +1,4 @@
 module PG
 	# Library version
-	VERSION = '1.4.3'
+	VERSION = '1.4.4'
 end


### PR DESCRIPTION
sequel_pg-1.16.0 introduced PQclear to fix a memory leek, but now a double free can happen, if there's an interrupt between PQclear and re-assiging a new PQresult. With this change the yielder can decide, if the result is cleared or not in the stream loop. In this case pgresult_clear() is called instead of PQclear, which avoids a double free.

This also raises the version to pg-1.4.4, so that sequel_pg can check for it.

Fixes #481