### PR TITLE
Return the libpq default port when blank in conninfo

### DIFF
--- a/ext/pg.c
+++ b/ext/pg.c
@@ -679,6 +679,9 @@ Init_pg_ext(void)
 	rb_define_const(rb_mPGconstants, "INVALID_OID", INT2FIX(InvalidOid));
 	rb_define_const(rb_mPGconstants, "InvalidOid", INT2FIX(InvalidOid));
 
+	/* PostgreSQL compiled in default port */
+	rb_define_const(rb_mPGconstants, "DEF_PGPORT", INT2FIX(DEF_PGPORT));
+
 	/* Add the constants to the toplevel namespace */
 	rb_include_module( rb_mPG, rb_mPGconstants );
 

--- a/ext/pg_connection.c
+++ b/ext/pg_connection.c
@@ -702,7 +702,10 @@ static VALUE
 pgconn_port(VALUE self)
 {
 	char* port = PQport(pg_get_pgconn(self));
-	return INT2NUM(atoi(port));
+	if (!port || port[0] == '\0')
+		return INT2NUM(DEF_PGPORT);
+	else
+		return INT2NUM(atoi(port));
 }
 
 /*

--- a/lib/pg/connection.rb
+++ b/lib/pg/connection.rb
@@ -723,6 +723,7 @@ class PG::Connection
 				# This requires PostgreSQL-10+, so no DNS resolving is done on earlier versions.
 				ihosts = iopts[:host].split(",", -1)
 				iports = iopts[:port].split(",", -1)
+				iports = [nil] if iports.size == 0
 				iports = iports * ihosts.size if iports.size == 1
 				raise PG::ConnectionBad, "could not match #{iports.size} port numbers to #{ihosts.size} hosts" if iports.size != ihosts.size
 

--- a/spec/pg/connection_spec.rb
+++ b/spec/pg/connection_spec.rb
@@ -731,6 +731,31 @@ describe PG::Connection do
 		expect( @conn.options ).to eq( "" )
 	end
 
+	it "connects without port and then retrieves the default port" do
+		gate = Helpers::TcpGateSwitcher.new(
+				external_host: 'localhost',
+				external_port: ENV['PGPORT'].to_i,
+				internal_host: "127.0.0.1",
+				internal_port: 5432,
+				debug: ENV['PG_DEBUG']=='1')
+
+		PG.connect(host: "localhost",
+				port: "",
+				dbname: "test") do |conn|
+			expect( conn.port ).to eq( 5432 )
+		end
+
+		PG.connect(hostaddr: "127.0.0.1",
+				port: nil,
+				dbname: "test") do |conn|
+			expect( conn.port ).to eq( 5432 )
+		end
+
+		gate.finish
+	rescue Errno::EADDRINUSE => err
+		skip err.to_s
+	end
+
 	it "can retrieve hostaddr for the established connection", :postgresql_12 do
 		expect( @conn.hostaddr ).to match( /^127\.0\.0\.1$|^::1$/ )
 	end

--- a/spec/pg/connection_spec.rb
+++ b/spec/pg/connection_spec.rb
@@ -736,19 +736,19 @@ describe PG::Connection do
 				external_host: 'localhost',
 				external_port: ENV['PGPORT'].to_i,
 				internal_host: "127.0.0.1",
-				internal_port: 5432,
+				internal_port: PG::DEF_PGPORT,
 				debug: ENV['PG_DEBUG']=='1')
 
 		PG.connect(host: "localhost",
 				port: "",
 				dbname: "test") do |conn|
-			expect( conn.port ).to eq( 5432 )
+			expect( conn.port ).to eq( PG::DEF_PGPORT )
 		end
 
 		PG.connect(hostaddr: "127.0.0.1",
 				port: nil,
 				dbname: "test") do |conn|
-			expect( conn.port ).to eq( 5432 )
+			expect( conn.port ).to eq( PG::DEF_PGPORT )
 		end
 
 		gate.finish


### PR DESCRIPTION
This is one potential fix for #491.

Internally, libpq checks for null or empty string stored in pg_conn_host and falls back to the configured default `--with-pgport`. This does the same for our wrapper around [PQport](https://www.postgresql.org/docs/current/libpq-status.html#LIBPQ-PQPORT).

- https://github.com/postgres/postgres/blob/REL_15_0/src/interfaces/libpq/fe-connect.c#L1140-L1146
- https://github.com/postgres/postgres/blob/REL_15_0/src/interfaces/libpq/fe-connect.c#L2385-L2387

```c
	/*
	 * Next, work out the port number corresponding to each host name.
	 *
	 * Note: unlike the above for host names, this could leave the port fields
	 * as null or empty strings.  We will substitute DEF_PGPORT whenever we
	 * read such a port field.
	 */
```

```c
		/* Figure out the port number we're going to use. */
		if (ch->port == NULL || ch->port[0] == '\0')
			thisport = DEF_PGPORT;
```

It has done this for a long time:

- https://github.com/postgres/postgres/blob/REL_10_0/src/interfaces/libpq/fe-connect.c#L1713-L1715
- https://github.com/postgres/postgres/blob/REL9_6_0/src/interfaces/libpq/fe-connect.c#L1419-L1433
- https://github.com/postgres/postgres/blob/REL8_3_0/src/interfaces/libpq/fe-connect.c#L793-L797