### PR TITLE
Improve copy_data error handling

### DIFF
--- a/lib/pg.rb
+++ b/lib/pg.rb
@@ -50,12 +50,6 @@ module PG
 		end
 	end
 
-
-	class NotAllCopyDataRetrieved < PG::Error
-	end
-	class NotInBlockingMode < PG::Error
-	end
-
 	# Get the PG library version.
 	#
 	# +include_buildnum+ is no longer used and any value passed will be ignored.

--- a/lib/pg/exceptions.rb
+++ b/lib/pg/exceptions.rb
@@ -14,5 +14,12 @@ module PG
 		end
 	end
 
+	class NotAllCopyDataRetrieved < PG::Error
+	end
+	class LostCopyState < PG::Error
+	end
+	class NotInBlockingMode < PG::Error
+	end
+
 end # module PG
 


### PR DESCRIPTION
Make sure an error in put_copy_end doesn't lose the original exception.

Use a dedicated error class PG::LostCopyState for errors due to another query while COPYing and mention that it's probably due to another query. Previously the "no COPY in progress" PG::Error was less specific.

Remove transactions around the "another query" specs, previously the put_copy_data direction had a double fault due to another query while transaction is in error state.

Use discard_result which we have now and which does essentially what previous error handling did.

Cleanup temporary tables after running.

Move definition of error classes to exception.rb, where they better fit into.