### PR TITLE
Update CI and improve `discard_results`

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -7,8 +7,11 @@ install:
   - ps: |
       if ($env:RUBYDOWNLOAD -ne $null) {
         $(new-object net.webclient).DownloadFile("https://github.com/oneclick/rubyinstaller2/releases/download/rubyinstaller-head/rubyinstaller-head-$env:RUBYDOWNLOAD.exe", "$pwd/ruby-setup.exe")
-        cmd /c ruby-setup.exe /verysilent /dir=C:/Ruby$env:ruby_version
+        cmd /c ruby-setup.exe /currentuser /verysilent /dir=C:/Ruby$env:ruby_version
       }
+  - cmd: |
+      ridk enable
+      c:/msys64/usr/bin/bash -lc "pacman -S --noconfirm --needed ${MINGW_PACKAGE_PREFIX}-pkgconf ${MINGW_PACKAGE_PREFIX}-libyaml ${MINGW_PACKAGE_PREFIX}-gcc"
   - ruby --version
   - gem --version
   - gem install bundler --conservative
@@ -18,19 +21,22 @@ install:
       {
         $(new-object net.webclient).DownloadFile('http://get.enterprisedb.com/postgresql/postgresql-' + $env:PGVERSION + '.exe', 'C:/postgresql-setup.exe')
         cmd /c "C:/postgresql-setup.exe" --mode unattended --extract-only 1
+
+        $env:PATH = 'C:/Program Files/PostgreSQL/' + $env:PGVER + '/bin;' + $env:PATH
+        $env:PATH = 'C:/Program Files (x86)/PostgreSQL/' + $env:PGVER + '/bin;' + $env:PATH
+      } else {
+        c:/msys64/usr/bin/bash -lc "pacman -S --noconfirm --needed `${MINGW_PACKAGE_PREFIX}-postgresql"
       }
-      $env:PATH = 'C:/Program Files/PostgreSQL/' + $env:PGVER + '/bin;' + $env:PATH
-      $env:PATH = 'C:/Program Files (x86)/PostgreSQL/' + $env:PGVER + '/bin;' + $env:PATH
+  - echo %PATH%
+  - pg_config
 build_script:
   - bundle exec rake -rdevkit compile --trace
 test_script:
   - bundle exec rake test PG_DEBUG=0
+on_failure:
+  - find -name mkmf.log | xargs cat
 environment:
   matrix:
     - ruby_version: "head"
       RUBYDOWNLOAD: x86
-      PGVERSION: 10.20-1-windows
-      PGVER: 10
-    - ruby_version: "25"
-      PGVERSION: 9.3.25-1-windows
-      PGVER: 9.3
+    - ruby_version: "30-x64"

--- a/.github/workflows/binary-gems.yml
+++ b/.github/workflows/binary-gems.yml
@@ -1,6 +1,11 @@
 name: Binary gems
 
-on: [push, pull_request]
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 5 * * 3" # At 05:00 on Wednesday # https://crontab.guru/#0_5_*_*_3
 
 jobs:
   job_build_x64:

--- a/.github/workflows/binary-gems.yml
+++ b/.github/workflows/binary-gems.yml
@@ -12,12 +12,13 @@ jobs:
         include:
           - platform: "x64-mingw-ucrt"
           - platform: "x64-mingw32"
+          - platform: "x86-mingw32"
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: "3.1"
+          ruby-version: "3.2"
       - run: bundle install
 
       - name: Create a dummy cert to satisfy the build
@@ -31,7 +32,7 @@ jobs:
         run: bundle exec rake gem:windows:${{ matrix.platform }}
 
       - name: Upload binary gem
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: binary-gem
           path: pkg/*.gem
@@ -43,25 +44,43 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - ruby: "3.1"
+          - os: windows-latest
+            ruby: "3.2"
             platform: "x64-mingw-ucrt"
             PGVERSION: 15.1-1-windows-x64
-          - ruby: "2.5"
+          - os: windows-latest
+            ruby: "3.1.3-1"
+            platform: "x86-mingw32"
+            PGVERSION: 10.20-1-windows
+          - os: windows-latest
+            ruby: "2.5"
             platform: "x64-mingw32"
             PGVERSION: 10.20-1-windows
 
-    runs-on: windows-latest
+    runs-on: ${{ matrix.os }}
     env:
       PGVERSION: ${{ matrix.PGVERSION }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up Ruby
+        if: matrix.platform != 'x86-mingw32'
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}
 
+      - name: Set up 32 bit x86 Ruby
+        if: matrix.platform == 'x86-mingw32'
+        run: |
+          $(new-object net.webclient).DownloadFile("https://github.com/oneclick/rubyinstaller2/releases/download/RubyInstaller-${{ matrix.ruby }}/rubyinstaller-${{ matrix.ruby }}-x86.exe", "$pwd/ruby-setup.exe")
+          cmd /c ruby-setup.exe /currentuser /verysilent /dir=C:/Ruby-${{ matrix.ruby }}
+          echo "c:/ruby-${{ matrix.ruby }}/bin"  | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+
+          c:/ruby-${{ matrix.ruby }}/bin/ridk enable
+          c:/msys64/usr/bin/bash -lc "pacman -S --noconfirm --needed make `${MINGW_PACKAGE_PREFIX}-pkgconf `${MINGW_PACKAGE_PREFIX}-libyaml `${MINGW_PACKAGE_PREFIX}-gcc `${MINGW_PACKAGE_PREFIX}-make"
+          echo "C:/msys64/$env:MSYSTEM_PREFIX/bin"  | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+
       - name: Download gem from build job
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: binary-gem
 
@@ -79,8 +98,15 @@ jobs:
           echo "PGUSER=$env:USERNAME"  | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
           echo "PGPASSWORD="  | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
 
+      - run: echo $env:PATH
       - run: gem update --system 3.3.26
       - run: bundle install
       - run: gem install --local pg-*${{ matrix.platform }}.gem --verbose
       - name: Run specs
         run: ruby -rpg -S rspec -fd spec/**/*_spec.rb
+
+      - name: Print logs if job failed
+        if: ${{ failure() && matrix.os == 'windows-latest' }}
+        run: |
+          ridk enable
+          find "$(ruby -e"puts RbConfig::CONFIG[%q[libdir]]")" -name mkmf.log -print0 | xargs -0 cat

--- a/.github/workflows/source-gem.yml
+++ b/.github/workflows/source-gem.yml
@@ -7,17 +7,17 @@ jobs:
     name: build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: "3.1"
+          ruby-version: "3.2"
 
       - name: Build source gem
         run: gem build pg.gemspec
 
       - name: Upload source gem
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: source-gem
           path: "*.gem"
@@ -41,7 +41,7 @@ jobs:
             ruby: "head"
             PGVER: "15"
           - os: ubuntu
-            ruby: "3.1"
+            ruby: "3.2"
             PGVER: "12"
           - os: ubuntu
             os_ver: "20.04"
@@ -65,14 +65,14 @@ jobs:
       MAKE: make -j2 V=1
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}
 
       - name: Download gem from build job
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: source-gem
 

--- a/.github/workflows/source-gem.yml
+++ b/.github/workflows/source-gem.yml
@@ -1,6 +1,11 @@
 name: Source gem
 
-on: [push, pull_request]
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 5 * * 3" # At 05:00 on Wednesday # https://crontab.guru/#0_5_*_*_3
 
 jobs:
   job_build_gem:

--- a/ext/pg_connection.c
+++ b/ext/pg_connection.c
@@ -3126,8 +3126,14 @@ pgconn_async_get_last_result(VALUE self)
  *    conn.discard_results()
  *
  * Silently discard any prior query result that application didn't eat.
- * This is done prior of Connection#exec and sibling methods and can
- * be called explicitly when using the async API.
+ * This is internally used prior to Connection#exec and sibling methods.
+ * It doesn't raise an exception on connection errors, but returns +false+ instead.
+ *
+ * Returns:
+ * * +nil+  when the connection is already idle
+ * * +true+  when some results have been discarded
+ * * +false+  when a failure occured and the connection was closed
+ *
  */
 static VALUE
 pgconn_discard_results(VALUE self)

--- a/ext/pg_connection.c
+++ b/ext/pg_connection.c
@@ -3142,8 +3142,12 @@ pgconn_discard_results(VALUE self)
 	PGconn *conn = pg_get_pgconn(self);
 	VALUE socket_io;
 
-	if( PQtransactionStatus(conn) == PQTRANS_IDLE ) {
-		return Qnil;
+	switch( PQtransactionStatus(conn) ) {
+		case PQTRANS_IDLE:
+		case PQTRANS_INTRANS:
+		case PQTRANS_INERROR:
+			return Qnil;
+		default:;
 	}
 
 	socket_io = pgconn_socket_io(self);

--- a/spec/helpers.rb
+++ b/spec/helpers.rb
@@ -688,7 +688,7 @@ RSpec.configure do |config|
 	config.filter_run_excluding( :postgresql_12 ) if PG.library_version < 120000
 	config.filter_run_excluding( :postgresql_14 ) if PG.library_version < 140000
 	config.filter_run_excluding( :unix_socket ) if RUBY_PLATFORM=~/mingw|mswin/i
-	config.filter_run_excluding( :scheduler ) if RUBY_VERSION < "3.0" || !Fiber.respond_to?(:scheduler)
+	config.filter_run_excluding( :scheduler ) if RUBY_VERSION < "3.0" || (RUBY_PLATFORM =~ /mingw|mswin/ && RUBY_VERSION < "3.1") || !Fiber.respond_to?(:scheduler)
 	config.filter_run_excluding( :scheduler_address_resolve ) if RUBY_VERSION < "3.1"
 	config.filter_run_excluding( :ipv6 ) if Addrinfo.getaddrinfo("localhost", nil, nil, :STREAM).size < 2
 

--- a/spec/pg/connection_spec.rb
+++ b/spec/pg/connection_spec.rb
@@ -642,7 +642,7 @@ describe PG::Connection do
 				skip "this spec depends on out-of-memory condition in put_copy_data, which is not reliable on all platforms"
 			end
 
-			run_with_gate(60) do |conn, gate|
+			run_with_gate(200) do |conn, gate|
 				conn.setnonblocking(true)
 
 				res = nil
@@ -668,7 +668,7 @@ describe PG::Connection do
 		end
 
 		it "needs to flush data after send_query" do
-			run_with_gate(60) do |conn, gate|
+			run_with_gate(200) do |conn, gate|
 				conn.setnonblocking(true)
 
 				gate.stop


### PR DESCRIPTION
This PR updates CI on Appveyor and Github Actions and adds a test of the binary gems for x86-mingw32.

Adding the platform x86-mingw32 showed that there can be issues with `discard_results` getting into starvation under memory pressure. So the second half of commits improve `discard_results` behavior, documentation and specs.
