### PR TITLE
Try to determine the path of PostgreSQL server commands from `pg_config`

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -207,7 +207,8 @@ PgはRuby-3.0で導入された`Fiber.scheduler`に完全に対応していま�
 
     $ bundle install
 
-拡張ファイル、パッケージファイル、テストデータベースを一掃するには次のようにします。
+Cleanup extension files, packaging files, test databases.  Run this to
+change between PostgreSQL versions:
 
     $ rake clean
 
@@ -215,13 +216,15 @@ PgはRuby-3.0で導入された`Fiber.scheduler`に完全に対応していま�
 
     $ rake compile
 
-パスにある`initdb`といったPostgreSQLのツールを使ってテストやスペックを走らせるには次のようにします。
+Run tests/specs on the PostgreSQL version that `pg_config --bindir` points
+to:
 
-    $ PATH=$PATH:/usr/lib/postgresql/14/bin rake test
+    $ rake test
 
-あるいは行番号を使って特定のテストを走らせるには次のようにします。
+Or run a specific test per file and line number on a specific PostgreSQL
+version:
 
-    $ PATH=$PATH:/usr/lib/postgresql/14/bin rspec -Ilib -fd spec/pg/connection_spec.rb:455
+    $ PATH=/usr/lib/postgresql/14/bin:$PATH rspec -Ilib -fd spec/pg/connection_spec.rb:455
 
 APIドキュメントを生成するには次のようにします。
 

--- a/README.md
+++ b/README.md
@@ -214,7 +214,8 @@ After checking out the source, install all dependencies:
 
     $ bundle install
 
-Cleanup extension files, packaging files, test databases:
+Cleanup extension files, packaging files, test databases.
+Run this to change between PostgreSQL versions:
 
     $ rake clean
 
@@ -222,13 +223,13 @@ Compile extension:
 
     $ rake compile
 
-Run tests/specs with PostgreSQL tools like `initdb` in the path:
+Run tests/specs on the PostgreSQL version that `pg_config --bindir` points to:
 
-    $ PATH=$PATH:/usr/lib/postgresql/14/bin rake test
+    $ rake test
 
-Or run a specific test with the line number:
+Or run a specific test per file and line number on a specific PostgreSQL version:
 
-    $ PATH=$PATH:/usr/lib/postgresql/14/bin rspec -Ilib -fd spec/pg/connection_spec.rb:455
+    $ PATH=/usr/lib/postgresql/14/bin:$PATH rspec -Ilib -fd spec/pg/connection_spec.rb:455
 
 Generate the API documentation:
 

--- a/translation/po4a.cfg
+++ b/translation/po4a.cfg
@@ -4,6 +4,8 @@
    --localized-charset UTF-8 \
    --master-language en \
    --option markdown \
-   --keep 0
+   --keep 0 \
+   --msgmerge-opt='--no-wrap' \
+   --wrap-po=newlines
 
 [type:text] ../README.md ja:../README.ja.md


### PR DESCRIPTION
`pg_config` is usually in the path of many distros, as soon as postgresql-client tools are installed, but server commands are not. That's why we always had to adjust the `PATH` accordingly. Determining the path of these commands automatically makes testing easier.