### PR TITLE
Add PG::TextEncoder::Bytea to BasicTypeRegistry

### DIFF
--- a/ext/pg_text_encoder.c
+++ b/ext/pg_text_encoder.c
@@ -383,8 +383,12 @@ static const char hextab[] = {
  *
  * The binary String is converted to hexadecimal representation for transmission
  * in text format. For query bind parameters it is recommended to use
- * PG::BinaryEncoder::Bytea instead, in order to decrease network traffic and
- * CPU usage.
+ * PG::BinaryEncoder::Bytea or the hash form <tt>{value: binary_string, format: 1}</tt> instead,
+ * in order to decrease network traffic and CPU usage.
+ * See PG::Connection#exec_params for using the hash form.
+ *
+ * This encoder is particular useful when PG::TextEncoder::CopyRow is used with the COPY command.
+ * In this case there's no way to change the format of a single column to binary, so that the data have to be converted to bytea hex representation.
  *
  */
 static int

--- a/lib/pg/basic_type_registry.rb
+++ b/lib/pg/basic_type_registry.rb
@@ -232,9 +232,7 @@ class PG::BasicTypeRegistry
 		# alias_type 'uuid',     'text'
 		#
 		# register_type 'money', OID::Money.new
-		# There is no PG::TextEncoder::Bytea, because it's simple and more efficient to send bytea-data
-		# in binary format, either with PG::BinaryEncoder::Bytea or in Hash param format.
-		register_type 0, 'bytea', nil, PG::TextDecoder::Bytea
+		register_type 0, 'bytea', PG::TextEncoder::Bytea, PG::TextDecoder::Bytea
 		register_type 0, 'bool', PG::TextEncoder::Boolean, PG::TextDecoder::Boolean
 		# register_type 'bit', OID::Bit.new
 		# register_type 'varbit', OID::Bit.new

--- a/spec/pg/basic_type_map_based_on_result_spec.rb
+++ b/spec/pg/basic_type_map_based_on_result_spec.rb
@@ -27,16 +27,16 @@ describe 'Basic type mapping' do
 
 		context "with usage of result oids for bind params encoder selection" do
 			it "can type cast query params" do
-				@conn.exec( "CREATE TEMP TABLE copytable (t TEXT, i INT, ai INT[])" )
+				@conn.exec( "CREATE TEMP TABLE copytable (t TEXT, i INT, ai INT[], by BYTEA)" )
 
 				# Retrieve table OIDs per empty result.
 				res = @conn.exec( "SELECT * FROM copytable LIMIT 0" )
 				tm = basic_type_mapping.build_column_map( res )
 
-				@conn.exec_params( "INSERT INTO copytable VALUES ($1, $2, $3)", ['a', 123, [5,4,3]], 0, tm )
-				@conn.exec_params( "INSERT INTO copytable VALUES ($1, $2, $3)", ['b', 234, [2,3]], 0, tm )
+				@conn.exec_params( "INSERT INTO copytable VALUES ($1, $2, $3, $4)", ['a', 123, [5,4,3], "\0\xFF'"], 0, tm )
+				@conn.exec_params( "INSERT INTO copytable VALUES ($1, $2, $3, $4)", ['b', 234, [2,3], "\"\n\r"], 0, tm )
 				res = @conn.exec( "SELECT * FROM copytable" )
-				expect( res.values ).to eq( [['a', '123', '{5,4,3}'], ['b', '234', '{2,3}']] )
+				expect( res.values ).to eq( [['a', '123', '{5,4,3}', '\x00ff27'], ['b', '234', '{2,3}', '\x220a0d']] )
 			end
 
 			it "can do JSON conversions", :postgresql_94 do


### PR DESCRIPTION
This encoder used to be excluded from the registry, since it's the only encoder that has a negative performance implication. However it should be there for completeness and because it's valuable for sending data per COPY command to the server.

Another issue was, that we supported PostgreSQL-8.4 to the time TextEncoder::Bytea was implemented, but the hex bytea format was introduced with PostgreSQL-9.0. Now we don't support such old versions any longer, so that the encoder can be used bar none.