### PR TITLE
Improve error message when query is canceled during streaming

### DIFF
--- a/ext/pg_result.c
+++ b/ext/pg_result.c
@@ -1480,6 +1480,9 @@ pgresult_stream_any(VALUE self, int (*yielder)(VALUE, int, int, void*), void* da
 		if( pgresult == NULL )
 			rb_raise( rb_eNoResultError, "no result received - possibly an intersection with another query");
 
+		if( nfields != PQnfields(pgresult) && PQnfields(pgresult) == 0 )
+			rb_raise(rb_eInvalidChangeOfResultFields, "number of fields changed in single row mode to 0 - this is a sign that the query was canceled or timed out");
+
 		if( nfields != PQnfields(pgresult) )
 			rb_raise( rb_eInvalidChangeOfResultFields, "number of fields changed in single row mode from %d to %d - this is a sign for intersection with another query", nfields, PQnfields(pgresult));
 


### PR DESCRIPTION
When streaming a result in single row mode, if this query is aborted - either because it timed out or some other reason -, `ruby-pg` raises the error:

```
PG::InvalidChangeOfResultFields: number of fields changed in single row
mode from X to 0 - this is a sign for intersection with another query
```

This error message is misleading and might confuse people. The number of fields changed to 0 because the result stopped being streamed.

This commit adds a different error message using the same exception class, explaining that the query was canceled or timed out.