### PR TITLE
Move nfields-check of stream-methods after result status check

### DIFF
--- a/spec/pg/result_spec.rb
+++ b/spec/pg/result_spec.rb
@@ -241,15 +241,30 @@ describe PG::Result do
 			}.to raise_error(PG::DivisionByZero)
 		end
 
-		it "raises an error if result number of rows change" do
+		it "raises an error if result number of fields change" do
 			@conn.send_query( "SELECT 1" )
 			@conn.set_single_row_mode
+			res = @conn.get_result
 			expect{
-				@conn.get_result.stream_each_row do
+				res.stream_each_row do
 					@conn.discard_results
 					@conn.send_query("SELECT 2,3");
+					@conn.set_single_row_mode
 				end
 			}.to raise_error(PG::InvalidChangeOfResultFields, /from 1 to 2 /)
+			expect( res.cleared? ).to be true
+		end
+
+		it "raises an error if there is a timeout during streaming" do
+			@conn.exec( "SET local statement_timeout = 20" )
+
+			@conn.send_query( "SELECT 1, true UNION ALL SELECT 2, (pg_sleep(0.1) IS NULL)" )
+			@conn.set_single_row_mode
+			expect{
+				@conn.get_result.stream_each_row do |row|
+					# No-op
+				end
+			}.to raise_error(PG::QueryCanceled, /statement timeout/)
 		end
 	end
 


### PR DESCRIPTION
This ensures that the nfield-check doesn't hide errors like statement timeout.

Now the new PGresult is assigned to the streaming PG::Result, even if it has a different number of fields. This avoids leaking the memory of the wrong PGresult, but would lead to wrong fields or segfaults, if the PG::Result is used afterwards. Therefore the result is getting cleared before the raise.

Thanks to Neil Carvalho @neilvcarvalho for the test case!

Fixes #507