### PR TITLE
Fix regression that PG::Coder derivates can only be initialized by keyword arguments

### DIFF
--- a/lib/pg/binary_decoder/timestamp.rb
+++ b/lib/pg/binary_decoder/timestamp.rb
@@ -5,18 +5,21 @@ module PG
 	module BinaryDecoder
 		# Convenience classes for timezone options
 		class TimestampUtc < Timestamp
-			def initialize(**kwargs)
-				super(flags: PG::Coder::TIMESTAMP_DB_UTC | PG::Coder::TIMESTAMP_APP_UTC, **kwargs)
+			def initialize(hash={}, **kwargs)
+				warn "PG::Coder.new(hash) is deprecated. Please use keyword arguments instead! Called from #{caller.first}" unless hash.empty?
+				super(flags: PG::Coder::TIMESTAMP_DB_UTC | PG::Coder::TIMESTAMP_APP_UTC, **hash, **kwargs)
 			end
 		end
 		class TimestampUtcToLocal < Timestamp
-			def initialize(**kwargs)
-				super(flags: PG::Coder::TIMESTAMP_DB_UTC | PG::Coder::TIMESTAMP_APP_LOCAL, **kwargs)
+			def initialize(hash={}, **kwargs)
+				warn "PG::Coder.new(hash) is deprecated. Please use keyword arguments instead! Called from #{caller.first}" unless hash.empty?
+				super(flags: PG::Coder::TIMESTAMP_DB_UTC | PG::Coder::TIMESTAMP_APP_LOCAL, **hash, **kwargs)
 			end
 		end
 		class TimestampLocal < Timestamp
-			def initialize(**kwargs)
-				super(flags: PG::Coder::TIMESTAMP_DB_LOCAL | PG::Coder::TIMESTAMP_APP_LOCAL, **kwargs)
+			def initialize(hash={}, **kwargs)
+				warn "PG::Coder.new(hash) is deprecated. Please use keyword arguments instead! Called from #{caller.first}" unless hash.empty?
+				super(flags: PG::Coder::TIMESTAMP_DB_LOCAL | PG::Coder::TIMESTAMP_APP_LOCAL, **hash, **kwargs)
 			end
 		end
 	end

--- a/lib/pg/binary_encoder/timestamp.rb
+++ b/lib/pg/binary_encoder/timestamp.rb
@@ -5,13 +5,15 @@ module PG
 	module BinaryEncoder
 		# Convenience classes for timezone options
 		class TimestampUtc < Timestamp
-			def initialize(**kwargs)
-				super(flags: PG::Coder::TIMESTAMP_DB_UTC, **kwargs)
+			def initialize(hash={}, **kwargs)
+				warn "PG::Coder.new(hash) is deprecated. Please use keyword arguments instead! Called from #{caller.first}" unless hash.empty?
+				super(flags: PG::Coder::TIMESTAMP_DB_UTC, **hash, **kwargs)
 			end
 		end
 		class TimestampLocal < Timestamp
-			def initialize(**kwargs)
-				super(flags: PG::Coder::TIMESTAMP_DB_LOCAL, **kwargs)
+			def initialize(hash={}, **kwargs)
+				warn "PG::Coder.new(hash) is deprecated. Please use keyword arguments instead! Called from #{caller.first}" unless hash.empty?
+				super(flags: PG::Coder::TIMESTAMP_DB_LOCAL, **hash, **kwargs)
 			end
 		end
 	end

--- a/lib/pg/coder.rb
+++ b/lib/pg/coder.rb
@@ -6,15 +6,18 @@ module PG
 	class Coder
 
 		module BinaryFormatting
-			def initialize( **kwargs )
-				super(format: 1, **kwargs)
+			def initialize(hash={}, **kwargs)
+				warn "PG::Coder.new(hash) is deprecated. Please use keyword arguments instead! Called from #{caller.first}" unless hash.empty?
+				super(format: 1, **hash, **kwargs)
 			end
 		end
 
 
 		# Create a new coder object based on the attribute Hash.
-		def initialize(**kwargs)
-			kwargs.each do |key, val|
+		def initialize(hash=nil, **kwargs)
+			warn "PG::Coder.new(hash) is deprecated. Please use keyword arguments instead! Called from #{caller.first}" if hash
+
+			(hash || kwargs).each do |key, val|
 				send("#{key}=", val)
 			end
 		end
@@ -42,7 +45,7 @@ module PG
 		end
 
 		def marshal_load(str)
-			initialize **Marshal.load(str)
+			initialize(**Marshal.load(str))
 		end
 
 		def inspect

--- a/lib/pg/text_decoder/timestamp.rb
+++ b/lib/pg/text_decoder/timestamp.rb
@@ -5,18 +5,21 @@ module PG
 	module TextDecoder
 		# Convenience classes for timezone options
 		class TimestampUtc < Timestamp
-			def initialize(**kwargs)
-				super(flags: PG::Coder::TIMESTAMP_DB_UTC | PG::Coder::TIMESTAMP_APP_UTC, **kwargs)
+			def initialize(hash={}, **kwargs)
+				warn "PG::Coder.new(hash) is deprecated. Please use keyword arguments instead! Called from #{caller.first}" unless hash.empty?
+				super(flags: PG::Coder::TIMESTAMP_DB_UTC | PG::Coder::TIMESTAMP_APP_UTC, **hash, **kwargs)
 			end
 		end
 		class TimestampUtcToLocal < Timestamp
-			def initialize(**kwargs)
-				super(flags: PG::Coder::TIMESTAMP_DB_UTC | PG::Coder::TIMESTAMP_APP_LOCAL, **kwargs)
+			def initialize(hash={}, **kwargs)
+				warn "PG::Coder.new(hash) is deprecated. Please use keyword arguments instead! Called from #{caller.first}" unless hash.empty?
+				super(flags: PG::Coder::TIMESTAMP_DB_UTC | PG::Coder::TIMESTAMP_APP_LOCAL, **hash, **kwargs)
 			end
 		end
 		class TimestampLocal < Timestamp
-			def initialize(**kwargs)
-				super(flags: PG::Coder::TIMESTAMP_DB_LOCAL | PG::Coder::TIMESTAMP_APP_LOCAL, **kwargs)
+			def initialize(hash={}, **kwargs)
+				warn "PG::Coder.new(hash) is deprecated. Please use keyword arguments instead! Called from #{caller.first}" unless hash.empty?
+				super(flags: PG::Coder::TIMESTAMP_DB_LOCAL | PG::Coder::TIMESTAMP_APP_LOCAL, **hash, **kwargs)
 			end
 		end
 

--- a/spec/pg/type_spec.rb
+++ b/spec/pg/type_spec.rb
@@ -508,9 +508,45 @@ describe "PG::Type derivations" do
 			expect( t.name ).to be_nil
 		end
 
-		it "should overwrite default values" do
+		it "should overwrite default values as kwargs" do
 			t = PG::BinaryEncoder::Int4.new(format: 0)
 			expect( t.format ).to eq( 0 )
+		end
+
+		it "should overwrite default values as hash" do
+			t = nil
+			expect do
+				t = PG::BinaryEncoder::Int4.new({format: 0})
+			end.to output(/deprecated.*type_spec.rb/).to_stderr
+			expect( t.format ).to eq( 0 )
+		end
+
+		it "should take hash argument" do
+			t = nil
+			expect { t = PG::TextEncoder::Integer.new({name: "abcä"}) }.to output(/deprecated.*type_spec.rb/).to_stderr
+			expect( t.name ).to eq( "abcä" )
+			expect { t = PG::BinaryEncoder::Int4.new({name: "abcä"}) }.to output(/deprecated.*type_spec.rb/).to_stderr
+			expect( t.name ).to eq( "abcä" )
+			expect { t = PG::BinaryDecoder::TimestampUtc.new({name: "abcä"}) }.to output(/deprecated.*type_spec.rb/).to_stderr
+			expect( t.name ).to eq( "abcä" )
+			expect { t = PG::BinaryDecoder::TimestampUtcToLocal.new({name: "abcä"}) }.to output(/deprecated.*type_spec.rb/).to_stderr
+			expect( t.name ).to eq( "abcä" )
+			expect { t = PG::BinaryDecoder::TimestampLocal.new({name: "abcä"}) }.to output(/deprecated.*type_spec.rb/).to_stderr
+			expect( t.name ).to eq( "abcä" )
+			expect { t = PG::BinaryEncoder::TimestampUtc.new({name: "abcä"}) }.to output(/deprecated.*type_spec.rb/).to_stderr
+			expect( t.name ).to eq( "abcä" )
+			expect { t = PG::BinaryEncoder::TimestampLocal.new({name: "abcä"}) }.to output(/deprecated.*type_spec.rb/).to_stderr
+			expect( t.name ).to eq( "abcä" )
+			expect { t = PG::TextDecoder::TimestampUtc.new({name: "abcä"}) }.to output(/deprecated.*type_spec.rb/).to_stderr
+			expect( t.name ).to eq( "abcä" )
+			expect { t = PG::TextDecoder::TimestampUtcToLocal.new({name: "abcä"}) }.to output(/deprecated.*type_spec.rb/).to_stderr
+			expect( t.name ).to eq( "abcä" )
+			expect { t = PG::TextDecoder::TimestampLocal.new({name: "abcä"}) }.to output(/deprecated.*type_spec.rb/).to_stderr
+			expect( t.name ).to eq( "abcä" )
+			expect { t = PG::TextDecoder::TimestampWithoutTimeZone.new({name: "abcä"}) }.to output(/deprecated.*type_spec.rb/).to_stderr
+			expect( t.name ).to eq( "abcä" )
+			expect { t = PG::TextDecoder::TimestampWithTimeZone.new({name: "abcä"}) }.to output(/deprecated.*type_spec.rb/).to_stderr
+			expect( t.name ).to eq( "abcä" )
 		end
 
 		it "should give account about memory usage" do

--- a/spec/pg/type_spec.rb
+++ b/spec/pg/type_spec.rb
@@ -513,39 +513,49 @@ describe "PG::Type derivations" do
 			expect( t.format ).to eq( 0 )
 		end
 
+		def expect_deprecated_coder_init
+			if RUBY_VERSION >= '3'
+				expect do
+					yield
+				end.to output(/deprecated.*type_spec.rb/).to_stderr
+			else
+				yield
+			end
+		end
+
 		it "should overwrite default values as hash" do
 			t = nil
-			expect do
+			expect_deprecated_coder_init do
 				t = PG::BinaryEncoder::Int4.new({format: 0})
-			end.to output(/deprecated.*type_spec.rb/).to_stderr
+			end
 			expect( t.format ).to eq( 0 )
 		end
 
 		it "should take hash argument" do
 			t = nil
-			expect { t = PG::TextEncoder::Integer.new({name: "abcä"}) }.to output(/deprecated.*type_spec.rb/).to_stderr
+			expect_deprecated_coder_init { t = PG::TextEncoder::Integer.new({name: "abcä"}) }
 			expect( t.name ).to eq( "abcä" )
-			expect { t = PG::BinaryEncoder::Int4.new({name: "abcä"}) }.to output(/deprecated.*type_spec.rb/).to_stderr
+			expect_deprecated_coder_init { t = PG::BinaryEncoder::Int4.new({name: "abcä"}) }
 			expect( t.name ).to eq( "abcä" )
-			expect { t = PG::BinaryDecoder::TimestampUtc.new({name: "abcä"}) }.to output(/deprecated.*type_spec.rb/).to_stderr
+			expect_deprecated_coder_init { t = PG::BinaryDecoder::TimestampUtc.new({name: "abcä"}) }
 			expect( t.name ).to eq( "abcä" )
-			expect { t = PG::BinaryDecoder::TimestampUtcToLocal.new({name: "abcä"}) }.to output(/deprecated.*type_spec.rb/).to_stderr
+			expect_deprecated_coder_init { t = PG::BinaryDecoder::TimestampUtcToLocal.new({name: "abcä"}) }
 			expect( t.name ).to eq( "abcä" )
-			expect { t = PG::BinaryDecoder::TimestampLocal.new({name: "abcä"}) }.to output(/deprecated.*type_spec.rb/).to_stderr
+			expect_deprecated_coder_init { t = PG::BinaryDecoder::TimestampLocal.new({name: "abcä"}) }
 			expect( t.name ).to eq( "abcä" )
-			expect { t = PG::BinaryEncoder::TimestampUtc.new({name: "abcä"}) }.to output(/deprecated.*type_spec.rb/).to_stderr
+			expect_deprecated_coder_init { t = PG::BinaryEncoder::TimestampUtc.new({name: "abcä"}) }
 			expect( t.name ).to eq( "abcä" )
-			expect { t = PG::BinaryEncoder::TimestampLocal.new({name: "abcä"}) }.to output(/deprecated.*type_spec.rb/).to_stderr
+			expect_deprecated_coder_init { t = PG::BinaryEncoder::TimestampLocal.new({name: "abcä"}) }
 			expect( t.name ).to eq( "abcä" )
-			expect { t = PG::TextDecoder::TimestampUtc.new({name: "abcä"}) }.to output(/deprecated.*type_spec.rb/).to_stderr
+			expect_deprecated_coder_init { t = PG::TextDecoder::TimestampUtc.new({name: "abcä"}) }
 			expect( t.name ).to eq( "abcä" )
-			expect { t = PG::TextDecoder::TimestampUtcToLocal.new({name: "abcä"}) }.to output(/deprecated.*type_spec.rb/).to_stderr
+			expect_deprecated_coder_init { t = PG::TextDecoder::TimestampUtcToLocal.new({name: "abcä"}) }
 			expect( t.name ).to eq( "abcä" )
-			expect { t = PG::TextDecoder::TimestampLocal.new({name: "abcä"}) }.to output(/deprecated.*type_spec.rb/).to_stderr
+			expect_deprecated_coder_init { t = PG::TextDecoder::TimestampLocal.new({name: "abcä"}) }
 			expect( t.name ).to eq( "abcä" )
-			expect { t = PG::TextDecoder::TimestampWithoutTimeZone.new({name: "abcä"}) }.to output(/deprecated.*type_spec.rb/).to_stderr
+			expect_deprecated_coder_init { t = PG::TextDecoder::TimestampWithoutTimeZone.new({name: "abcä"}) }
 			expect( t.name ).to eq( "abcä" )
-			expect { t = PG::TextDecoder::TimestampWithTimeZone.new({name: "abcä"}) }.to output(/deprecated.*type_spec.rb/).to_stderr
+			expect_deprecated_coder_init { t = PG::TextDecoder::TimestampWithTimeZone.new({name: "abcä"}) }
 			expect( t.name ).to eq( "abcä" )
 		end
 


### PR DESCRIPTION
This re-enables initialization per Hash, which was removed in commit fd8bdbbcd0f270e1368a4a56bf6781494e96f1d7

Also add deprecation warning about Hash arguments like: 
```ruby
PG::Coder.new(hash) is deprecated. Please use keyword arguments instead! Called from [...]gems/activerecord-6.1.7.3/lib/active_record/connection_adapters/postgresql_adapter.rb:883:in `new'
```
