### PR TITLE
Add write barriers to PG classes

### DIFF
--- a/ext/pg_coder.c
+++ b/ext/pg_coder.c
@@ -35,7 +35,7 @@ pg_coder_init_encoder( VALUE self )
 		this->enc_func = NULL;
 	}
 	this->dec_func = NULL;
-	this->coder_obj = self;
+	RB_OBJ_WRITE(self, &this->coder_obj, self);
 	this->oid = 0;
 	this->format = 0;
 	this->flags = 0;
@@ -54,7 +54,7 @@ pg_coder_init_decoder( VALUE self )
 	} else {
 		this->dec_func = NULL;
 	}
-	this->coder_obj = self;
+	RB_OBJ_WRITE(self, &this->coder_obj, self);
 	this->oid = 0;
 	this->format = 0;
 	this->flags = 0;
@@ -99,7 +99,9 @@ const rb_data_type_t pg_coder_type = {
 	},
 	0,
 	0,
-	RUBY_TYPED_FREE_IMMEDIATELY,
+	// IMPORTANT: WB_PROTECTED objects must only use the RB_OBJ_WRITE()
+	// macro to update VALUE references, as to trigger write barriers.
+	RUBY_TYPED_FREE_IMMEDIATELY | RUBY_TYPED_WB_PROTECTED,
 };
 
 static VALUE
@@ -121,7 +123,7 @@ static const rb_data_type_t pg_composite_coder_type = {
 	},
 	&pg_coder_type,
 	0,
-	RUBY_TYPED_FREE_IMMEDIATELY,
+	RUBY_TYPED_FREE_IMMEDIATELY | RUBY_TYPED_WB_PROTECTED,
 };
 
 static VALUE
@@ -452,7 +454,7 @@ static const rb_data_type_t pg_coder_cfunc_type = {
 	},
 	0,
 	0,
-	RUBY_TYPED_FREE_IMMEDIATELY,
+	RUBY_TYPED_FREE_IMMEDIATELY | RUBY_TYPED_WB_PROTECTED,
 };
 
 VALUE

--- a/ext/pg_connection.c
+++ b/ext/pg_connection.c
@@ -1158,7 +1158,7 @@ static const rb_data_type_t pg_typecast_buffer_type = {
 	},
 	0,
 	0,
-	RUBY_TYPED_FREE_IMMEDIATELY,
+	RUBY_TYPED_FREE_IMMEDIATELY | RUBY_TYPED_WB_PROTECTED,
 };
 
 static char *
@@ -1191,7 +1191,7 @@ static const rb_data_type_t pg_query_heap_pool_type = {
 	},
 	0,
 	0,
-	RUBY_TYPED_FREE_IMMEDIATELY,
+	RUBY_TYPED_FREE_IMMEDIATELY | RUBY_TYPED_WB_PROTECTED,
 };
 
 static int

--- a/ext/pg_connection.c
+++ b/ext/pg_connection.c
@@ -117,7 +117,7 @@ pgconn_close_socket_io( VALUE self )
 		rb_funcall( socket_io, rb_intern("close"), 0 );
 	}
 
-	this->socket_io = Qnil;
+	RB_OBJ_WRITE(self, &this->socket_io, Qnil);
 }
 
 
@@ -237,7 +237,7 @@ static const rb_data_type_t pg_connection_type = {
 	},
 	0,
 	0,
-	0,
+	RUBY_TYPED_WB_PROTECTED,
 };
 
 
@@ -258,14 +258,14 @@ pgconn_s_allocate( VALUE klass )
 	VALUE self = TypedData_Make_Struct( klass, t_pg_connection, &pg_connection_type, this );
 
 	this->pgconn = NULL;
-	this->socket_io = Qnil;
-	this->notice_receiver = Qnil;
-	this->notice_processor = Qnil;
-	this->type_map_for_queries = pg_typemap_all_strings;
-	this->type_map_for_results = pg_typemap_all_strings;
-	this->encoder_for_put_copy_data = Qnil;
-	this->decoder_for_get_copy_data = Qnil;
-	this->trace_stream = Qnil;
+	RB_OBJ_WRITE(self, &this->socket_io, Qnil);
+	RB_OBJ_WRITE(self, &this->notice_receiver, Qnil);
+	RB_OBJ_WRITE(self, &this->notice_processor, Qnil);
+	RB_OBJ_WRITE(self, &this->type_map_for_queries, pg_typemap_all_strings);
+	RB_OBJ_WRITE(self, &this->type_map_for_results, pg_typemap_all_strings);
+	RB_OBJ_WRITE(self, &this->encoder_for_put_copy_data, Qnil);
+	RB_OBJ_WRITE(self, &this->decoder_for_get_copy_data, Qnil);
+	RB_OBJ_WRITE(self, &this->trace_stream, Qnil);
 	rb_ivar_set(self, rb_intern("@calls_to_put_copy_data"), INT2FIX(0));
 
 	return self;
@@ -941,7 +941,7 @@ pgconn_socket_io(VALUE self)
 		/* Disable autoclose feature */
 		rb_funcall( socket_io, s_id_autoclose_set, 1, Qfalse );
 
-		this->socket_io = socket_io;
+		RB_OBJ_WRITE(self, &this->socket_io, socket_io);
 	}
 
 	return socket_io;
@@ -2739,7 +2739,7 @@ pgconn_trace(VALUE self, VALUE stream)
 		rb_raise(rb_eArgError, "stream is not writable");
 
 	new_file = rb_funcall(rb_cIO, rb_intern("new"), 1, INT2NUM(new_fd));
-	this->trace_stream = new_file;
+	RB_OBJ_WRITE(self, &this->trace_stream, new_file);
 
 	PQtrace(this->pgconn, new_fp);
 	return Qnil;
@@ -2758,7 +2758,7 @@ pgconn_untrace(VALUE self)
 
 	PQuntrace(this->pgconn);
 	rb_funcall(this->trace_stream, rb_intern("close"), 0);
-	this->trace_stream = Qnil;
+	RB_OBJ_WRITE(self, &this->trace_stream, Qnil);
 	return Qnil;
 }
 
@@ -2835,7 +2835,7 @@ pgconn_set_notice_receiver(VALUE self)
 		PQsetNoticeReceiver(this->pgconn, default_notice_receiver, NULL);
 	}
 
-	this->notice_receiver = proc;
+	RB_OBJ_WRITE(self, &this->notice_receiver, proc);
 	return old_proc;
 }
 
@@ -2850,10 +2850,10 @@ notice_processor_proxy(void *arg, const char *message)
 	VALUE self = (VALUE)arg;
 	t_pg_connection *this = pg_get_connection( self );
 
-	if (this->notice_receiver != Qnil) {
+	if (this->notice_processor != Qnil) {
 		VALUE message_str = rb_str_new2(message);
 		PG_ENCODING_SET_NOCHECK( message_str, this->enc_idx );
-		rb_funcall(this->notice_receiver, rb_intern("call"), 1, message_str);
+		rb_funcall(this->notice_processor, rb_intern("call"), 1, message_str);
 	}
 	return;
 }
@@ -2885,7 +2885,7 @@ pgconn_set_notice_processor(VALUE self)
 	if(default_notice_processor == NULL)
 		default_notice_processor = PQsetNoticeProcessor(this->pgconn, NULL, NULL);
 
-	old_proc = this->notice_receiver;
+	old_proc = this->notice_processor;
 	if( rb_block_given_p() ) {
 		proc = rb_block_proc();
 		PQsetNoticeProcessor(this->pgconn, gvl_notice_processor_proxy, (void *)self);
@@ -2895,7 +2895,7 @@ pgconn_set_notice_processor(VALUE self)
 		PQsetNoticeProcessor(this->pgconn, default_notice_processor, NULL);
 	}
 
-	this->notice_receiver = proc;
+	RB_OBJ_WRITE(self, &this->notice_processor, proc);
 	return old_proc;
 }
 
@@ -4196,7 +4196,7 @@ pgconn_type_map_for_queries_set(VALUE self, VALUE typemap)
 	/* Check type of method param */
 	TypedData_Get_Struct(typemap, t_typemap, &pg_typemap_type, tm);
 
-	this->type_map_for_queries = typemap;
+	RB_OBJ_WRITE(self, &this->type_map_for_queries, typemap);
 
 	return typemap;
 }
@@ -4234,7 +4234,7 @@ pgconn_type_map_for_results_set(VALUE self, VALUE typemap)
 	UNUSED(tm);
 
 	TypedData_Get_Struct(typemap, t_typemap, &pg_typemap_type, tm);
-	this->type_map_for_results = typemap;
+	RB_OBJ_WRITE(self, &this->type_map_for_results, typemap);
 
 	return typemap;
 }
@@ -4278,7 +4278,7 @@ pgconn_encoder_for_put_copy_data_set(VALUE self, VALUE encoder)
 		/* Check argument type */
 		TypedData_Get_Struct(encoder, t_pg_coder, &pg_coder_type, co);
 	}
-	this->encoder_for_put_copy_data = encoder;
+	RB_OBJ_WRITE(self, &this->encoder_for_put_copy_data, encoder);
 
 	return encoder;
 }
@@ -4326,7 +4326,7 @@ pgconn_decoder_for_get_copy_data_set(VALUE self, VALUE decoder)
 		/* Check argument type */
 		TypedData_Get_Struct(decoder, t_pg_coder, &pg_coder_type, co);
 	}
-	this->decoder_for_get_copy_data = decoder;
+	RB_OBJ_WRITE(self, &this->decoder_for_get_copy_data, decoder);
 
 	return decoder;
 }

--- a/ext/pg_copy_coder.c
+++ b/ext/pg_copy_coder.c
@@ -55,7 +55,7 @@ static const rb_data_type_t pg_copycoder_type = {
 	},
 	&pg_coder_type,
 	0,
-	RUBY_TYPED_FREE_IMMEDIATELY,
+	RUBY_TYPED_FREE_IMMEDIATELY | RUBY_TYPED_WB_PROTECTED,
 };
 
 static VALUE
@@ -64,9 +64,9 @@ pg_copycoder_encoder_allocate( VALUE klass )
 	t_pg_copycoder *this;
 	VALUE self = TypedData_Make_Struct( klass, t_pg_copycoder, &pg_copycoder_type, this );
 	pg_coder_init_encoder( self );
-	this->typemap = pg_typemap_all_strings;
+	RB_OBJ_WRITE(self, &this->typemap, pg_typemap_all_strings);
 	this->delimiter = '\t';
-	this->null_string = rb_str_new_cstr("\\N");
+	RB_OBJ_WRITE(self, &this->null_string, rb_str_new_cstr("\\N"));
 	return self;
 }
 
@@ -76,9 +76,9 @@ pg_copycoder_decoder_allocate( VALUE klass )
 	t_pg_copycoder *this;
 	VALUE self = TypedData_Make_Struct( klass, t_pg_copycoder, &pg_copycoder_type, this );
 	pg_coder_init_decoder( self );
-	this->typemap = pg_typemap_all_strings;
+	RB_OBJ_WRITE(self, &this->typemap, pg_typemap_all_strings);
 	this->delimiter = '\t';
-	this->null_string = rb_str_new_cstr("\\N");
+	RB_OBJ_WRITE(self, &this->null_string, rb_str_new_cstr("\\N"));
 	return self;
 }
 
@@ -128,7 +128,7 @@ pg_copycoder_null_string_set(VALUE self, VALUE null_string)
 {
 	t_pg_copycoder *this = RTYPEDDATA_DATA(self);
 	StringValue(null_string);
-	this->null_string = null_string;
+	RB_OBJ_WRITE(self, &this->null_string, null_string);
 	return null_string;
 }
 
@@ -162,7 +162,7 @@ pg_copycoder_type_map_set(VALUE self, VALUE type_map)
 		rb_raise( rb_eTypeError, "wrong elements type %s (expected some kind of PG::TypeMap)",
 				rb_obj_classname( type_map ) );
 	}
-	this->typemap = type_map;
+	RB_OBJ_WRITE(self, &this->typemap, type_map);
 
 	return type_map;
 }

--- a/ext/pg_record_coder.c
+++ b/ext/pg_record_coder.c
@@ -47,7 +47,7 @@ static const rb_data_type_t pg_recordcoder_type = {
 	},
 	&pg_coder_type,
 	0,
-	RUBY_TYPED_FREE_IMMEDIATELY,
+	RUBY_TYPED_FREE_IMMEDIATELY | RUBY_TYPED_WB_PROTECTED,
 };
 
 static VALUE
@@ -56,7 +56,7 @@ pg_recordcoder_encoder_allocate( VALUE klass )
 	t_pg_recordcoder *this;
 	VALUE self = TypedData_Make_Struct( klass, t_pg_recordcoder, &pg_recordcoder_type, this );
 	pg_coder_init_encoder( self );
-	this->typemap = pg_typemap_all_strings;
+	RB_OBJ_WRITE(self, &this->typemap, pg_typemap_all_strings);
 	return self;
 }
 
@@ -66,7 +66,7 @@ pg_recordcoder_decoder_allocate( VALUE klass )
 	t_pg_recordcoder *this;
 	VALUE self = TypedData_Make_Struct( klass, t_pg_recordcoder, &pg_recordcoder_type, this );
 	pg_coder_init_decoder( self );
-	this->typemap = pg_typemap_all_strings;
+	RB_OBJ_WRITE(self, &this->typemap, pg_typemap_all_strings);
 	return self;
 }
 
@@ -90,7 +90,7 @@ pg_recordcoder_type_map_set(VALUE self, VALUE type_map)
 		rb_raise( rb_eTypeError, "wrong elements type %s (expected some kind of PG::TypeMap)",
 				rb_obj_classname( type_map ) );
 	}
-	this->typemap = type_map;
+	RB_OBJ_WRITE(self, &this->typemap, type_map);
 
 	return type_map;
 }

--- a/ext/pg_type_map.c
+++ b/ext/pg_type_map.c
@@ -37,7 +37,7 @@ const rb_data_type_t pg_typemap_type = {
 	},
 	0,
 	0,
-	RUBY_TYPED_FREE_IMMEDIATELY,
+	RUBY_TYPED_FREE_IMMEDIATELY | RUBY_TYPED_WB_PROTECTED,
 };
 
 VALUE rb_cTypeMap;
@@ -134,7 +134,7 @@ pg_typemap_default_type_map_set(VALUE self, VALUE typemap)
 
 	/* Check type of method param */
 	TypedData_Get_Struct(typemap, t_typemap, &pg_typemap_type, tm);
-	this->default_typemap = typemap;
+	RB_OBJ_WRITE(self, &this->default_typemap, typemap);
 
 	return typemap;
 }

--- a/ext/pg_type_map_all_strings.c
+++ b/ext/pg_type_map_all_strings.c
@@ -18,7 +18,7 @@ static const rb_data_type_t pg_tmas_type = {
 	},
 	&pg_typemap_type,
 	0,
-	RUBY_TYPED_FREE_IMMEDIATELY,
+	RUBY_TYPED_FREE_IMMEDIATELY | RUBY_TYPED_WB_PROTECTED,
 };
 
 VALUE rb_cTypeMapAllStrings;

--- a/ext/pg_type_map_by_class.c
+++ b/ext/pg_type_map_by_class.c
@@ -157,7 +157,7 @@ static const rb_data_type_t pg_tmbk_type = {
 	},
 	&pg_typemap_type,
 	0,
-	RUBY_TYPED_FREE_IMMEDIATELY,
+	RUBY_TYPED_FREE_IMMEDIATELY | RUBY_TYPED_WB_PROTECTED,
 };
 
 static VALUE
@@ -173,12 +173,12 @@ pg_tmbk_s_allocate( VALUE klass )
 	this->typemap.funcs.typecast_result_value = pg_typemap_result_value;
 	this->typemap.funcs.typecast_query_param = pg_tmbk_typecast_query_param;
 	this->typemap.funcs.typecast_copy_get = pg_typemap_typecast_copy_get;
-	this->typemap.default_typemap = pg_typemap_all_strings;
+	RB_OBJ_WRITE(self, &this->typemap.default_typemap, pg_typemap_all_strings);
 
 	/* We need to store self in the this-struct, because pg_tmbk_typecast_query_param(),
 	 * is called with the this-pointer only. */
 	this->self = self;
-	this->klass_to_coder = rb_hash_new();
+	RB_OBJ_WRITE(self, &this->klass_to_coder, rb_hash_new());
 
 	/* The cache is properly initialized by TypedData_Make_Struct(). */
 

--- a/ext/pg_type_map_by_oid.c
+++ b/ext/pg_type_map_by_oid.c
@@ -194,7 +194,7 @@ static const rb_data_type_t pg_tmbo_type = {
 	},
 	&pg_typemap_type,
 	0,
-	RUBY_TYPED_FREE_IMMEDIATELY,
+	RUBY_TYPED_FREE_IMMEDIATELY | RUBY_TYPED_WB_PROTECTED,
 };
 
 static VALUE
@@ -212,11 +212,11 @@ pg_tmbo_s_allocate( VALUE klass )
 	this->typemap.funcs.typecast_result_value = pg_tmbo_result_value;
 	this->typemap.funcs.typecast_query_param = pg_typemap_typecast_query_param;
 	this->typemap.funcs.typecast_copy_get = pg_typemap_typecast_copy_get;
-	this->typemap.default_typemap = pg_typemap_all_strings;
+	RB_OBJ_WRITE(self, &this->typemap.default_typemap, pg_typemap_all_strings);
 	this->max_rows_for_online_lookup = 10;
 
 	for( i=0; i<2; i++){
-		this->format[i].oid_to_coder = rb_hash_new();
+		RB_OBJ_WRITE(self, &this->format[i].oid_to_coder, rb_hash_new());
 	}
 
 	return self;

--- a/ext/pg_type_map_in_ruby.c
+++ b/ext/pg_type_map_in_ruby.c
@@ -44,7 +44,7 @@ static const rb_data_type_t pg_tmir_type = {
 	},
 	&pg_typemap_type,
 	0,
-	RUBY_TYPED_FREE_IMMEDIATELY,
+	RUBY_TYPED_FREE_IMMEDIATELY | RUBY_TYPED_WB_PROTECTED,
 };
 
 /*
@@ -294,7 +294,7 @@ pg_tmir_s_allocate( VALUE klass )
 	this->typemap.funcs.typecast_result_value = pg_tmir_result_value;
 	this->typemap.funcs.typecast_query_param = pg_tmir_query_param;
 	this->typemap.funcs.typecast_copy_get = pg_tmir_copy_get;
-	this->typemap.default_typemap = pg_typemap_all_strings;
+	RB_OBJ_WRITE(self, &this->typemap.default_typemap, pg_typemap_all_strings);
 	this->self = self;
 
 	return self;


### PR DESCRIPTION
Write barrier protected objects are allowed to be promoted to the old generation, which means they only get marked on major GC. The downside is that the RB_BJ_WRITE macro MUST be used to set references, otherwise the referenced object may be garbaged collected.