### PR TITLE
Make PG classes shareable and usable with Ractor

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ If messages like the following are printed to stderr, you're probably using one 
 
 ## Fiber IO scheduler support
 
-Pg is fully compatible with `Fiber.scheduler` introduced in Ruby-3.0.
+Pg is fully compatible with `Fiber.scheduler` introduced in Ruby-3.0 since pg-1.3.0.
 On Windows support for `Fiber.scheduler` is available on Ruby-3.1 or newer.
 All possibly blocking IO operations are routed through the `Fiber.scheduler` if one is registered for the running thread.
 That is why pg internally uses the asynchronous libpq interface even for synchronous/blocking method calls.
@@ -206,6 +206,16 @@ When `PG::Connection.setnonblocking(true)` is called then the nonblocking state 
 An exception to this rule are the methods for large objects like `PG::Connection#lo_create` and authentication methods using external libraries (like GSSAPI authentication).
 They are not compatible with `Fiber.scheduler`, so that blocking states are not passed to the registered IO scheduler.
 That means the operation will work properly, but IO waiting states can not be used to switch to another Fiber doing IO.
+
+
+## Ractor support
+
+Pg is fully compatible with Ractor introduced in Ruby-3.0 since pg-1.5.0.
+All type en/decoders and type maps are shareable between ractors if they are made frozen by `Ractor.make_shareable`.
+Also frozen PG::Result and PG::Tuple objects can be shared.
+All frozen objects (except PG::Connection) can still be used to do communication with the PostgreSQL server or to read retrieved data.
+
+PG::Connection is not shareable and must be created within each Ractor to establish a dedicated connection.
 
 
 ## Contributing

--- a/ext/pg.c
+++ b/ext/pg.c
@@ -334,6 +334,11 @@ pg_s_init_ssl(VALUE self, VALUE do_ssl)
 void
 Init_pg_ext(void)
 {
+
+#ifdef HAVE_RB_EXT_RACTOR_SAFE
+	rb_ext_ractor_safe(PQisthreadsafe());
+#endif
+
 	if( RTEST(rb_eval_string("ENV['PG_SKIP_DEPRECATION_WARNING']")) ){
 		/* Set all bits to disable all deprecation warnings. */
 		pg_skip_deprecation_warning = 0xFFFF;
@@ -685,4 +690,3 @@ Init_pg_ext(void)
 	init_pg_recordcoder();
 	init_pg_tuple();
 }
-

--- a/ext/pg.h
+++ b/ext/pg.h
@@ -89,6 +89,12 @@ typedef long suseconds_t;
 #define pg_gc_location(x) UNUSED(x)
 #endif
 
+/* For compatibility with ruby < 3.0 */
+#ifndef RUBY_TYPED_FROZEN_SHAREABLE
+#define PG_RUBY_TYPED_FROZEN_SHAREABLE 0
+#else
+#define PG_RUBY_TYPED_FROZEN_SHAREABLE RUBY_TYPED_FROZEN_SHAREABLE
+#endif
 #define PG_ENC_IDX_BITS 28
 
 /* The data behind each PG::Connection object */

--- a/ext/pg_coder.c
+++ b/ext/pg_coder.c
@@ -101,7 +101,7 @@ const rb_data_type_t pg_coder_type = {
 	0,
 	// IMPORTANT: WB_PROTECTED objects must only use the RB_OBJ_WRITE()
 	// macro to update VALUE references, as to trigger write barriers.
-	RUBY_TYPED_FREE_IMMEDIATELY | RUBY_TYPED_WB_PROTECTED,
+	RUBY_TYPED_FREE_IMMEDIATELY | RUBY_TYPED_WB_PROTECTED | PG_RUBY_TYPED_FROZEN_SHAREABLE,
 };
 
 static VALUE
@@ -123,7 +123,7 @@ static const rb_data_type_t pg_composite_coder_type = {
 	},
 	&pg_coder_type,
 	0,
-	RUBY_TYPED_FREE_IMMEDIATELY | RUBY_TYPED_WB_PROTECTED,
+	RUBY_TYPED_FREE_IMMEDIATELY | RUBY_TYPED_WB_PROTECTED | PG_RUBY_TYPED_FROZEN_SHAREABLE,
 };
 
 static VALUE
@@ -275,6 +275,7 @@ static VALUE
 pg_coder_oid_set(VALUE self, VALUE oid)
 {
 	t_pg_coder *this = RTYPEDDATA_DATA(self);
+	rb_check_frozen(self);
 	this->oid = NUM2UINT(oid);
 	return oid;
 }
@@ -306,6 +307,7 @@ static VALUE
 pg_coder_format_set(VALUE self, VALUE format)
 {
 	t_pg_coder *this = RTYPEDDATA_DATA(self);
+	rb_check_frozen(self);
 	this->format = NUM2INT(format);
 	return format;
 }
@@ -337,6 +339,7 @@ static VALUE
 pg_coder_flags_set(VALUE self, VALUE flags)
 {
 	t_pg_coder *this = RTYPEDDATA_DATA(self);
+	rb_check_frozen(self);
 	this->flags = NUM2INT(flags);
 	return flags;
 }
@@ -368,6 +371,7 @@ static VALUE
 pg_coder_needs_quotation_set(VALUE self, VALUE needs_quotation)
 {
 	t_pg_composite_coder *this = RTYPEDDATA_DATA(self);
+	rb_check_frozen(self);
 	this->needs_quotation = RTEST(needs_quotation);
 	return needs_quotation;
 }
@@ -398,6 +402,7 @@ static VALUE
 pg_coder_delimiter_set(VALUE self, VALUE delimiter)
 {
 	t_pg_composite_coder *this = RTYPEDDATA_DATA(self);
+	rb_check_frozen(self);
 	StringValue(delimiter);
 	if(RSTRING_LEN(delimiter) != 1)
 		rb_raise( rb_eArgError, "delimiter size must be one byte");
@@ -432,6 +437,7 @@ pg_coder_elements_type_set(VALUE self, VALUE elem_type)
 {
 	t_pg_composite_coder *this = RTYPEDDATA_DATA( self );
 
+	rb_check_frozen(self);
 	if ( NIL_P(elem_type) ){
 		this->elem = NULL;
 	} else if ( rb_obj_is_kind_of(elem_type, rb_cPG_Coder) ){

--- a/ext/pg_coder.c
+++ b/ext/pg_coder.c
@@ -460,7 +460,7 @@ static const rb_data_type_t pg_coder_cfunc_type = {
 	},
 	0,
 	0,
-	RUBY_TYPED_FREE_IMMEDIATELY | RUBY_TYPED_WB_PROTECTED,
+	RUBY_TYPED_FREE_IMMEDIATELY | RUBY_TYPED_WB_PROTECTED | PG_RUBY_TYPED_FROZEN_SHAREABLE,
 };
 
 VALUE
@@ -476,7 +476,7 @@ pg_define_coder( const char *name, void *func, VALUE base_klass, VALUE nsp )
 	if( nsp==rb_mPG_BinaryDecoder || nsp==rb_mPG_TextDecoder )
 		rb_define_method( coder_klass, "decode", pg_coder_decode, -1 );
 
-	rb_define_const( coder_klass, "CFUNC", cfunc_obj );
+	rb_define_const( coder_klass, "CFUNC", rb_obj_freeze(cfunc_obj) );
 
 	RB_GC_GUARD(cfunc_obj);
 	return coder_klass;

--- a/ext/pg_connection.c
+++ b/ext/pg_connection.c
@@ -1811,6 +1811,7 @@ pgconn_set_single_row_mode(VALUE self)
 {
 	PGconn *conn = pg_get_pgconn(self);
 
+	rb_check_frozen(self);
 	if( PQsetSingleRowMode(conn) == 0 )
 		pg_raise_conn_error( rb_ePGerror, self, "%s", PQerrorMessage(conn));
 
@@ -2145,6 +2146,7 @@ pgconn_sync_setnonblocking(VALUE self, VALUE state)
 {
 	int arg;
 	PGconn *conn = pg_get_pgconn(self);
+	rb_check_frozen(self);
 	if(state == Qtrue)
 		arg = 1;
 	else if (state == Qfalse)
@@ -2461,6 +2463,7 @@ pgconn_wait_for_flush( VALUE self ){
 static VALUE
 pgconn_flush_data_set( VALUE self, VALUE enabled ){
 	t_pg_connection *conn = pg_get_connection(self);
+	rb_check_frozen(self);
 	conn->flush_data = RTEST(enabled);
 	return enabled;
 }
@@ -2715,6 +2718,7 @@ pgconn_trace(VALUE self, VALUE stream)
 	VALUE new_file;
 	t_pg_connection *this = pg_get_connection_safe( self );
 
+	rb_check_frozen(self);
 	if(!rb_respond_to(stream,rb_intern("fileno")))
 		rb_raise(rb_eArgError, "stream does not respond to method: fileno");
 
@@ -2814,6 +2818,7 @@ pgconn_set_notice_receiver(VALUE self)
 	VALUE proc, old_proc;
 	t_pg_connection *this = pg_get_connection_safe( self );
 
+	rb_check_frozen(self);
 	/* If default_notice_receiver is unset, assume that the current
 	 * notice receiver is the default, and save it to a global variable.
 	 * This should not be a problem because the default receiver is
@@ -2874,6 +2879,7 @@ pgconn_set_notice_processor(VALUE self)
 	VALUE proc, old_proc;
 	t_pg_connection *this = pg_get_connection_safe( self );
 
+	rb_check_frozen(self);
 	/* If default_notice_processor is unset, assume that the current
 	 * notice processor is the default, and save it to a global variable.
 	 * This should not be a problem because the default processor is
@@ -2924,6 +2930,7 @@ pgconn_sync_set_client_encoding(VALUE self, VALUE str)
 {
 	PGconn *conn = pg_get_pgconn( self );
 
+	rb_check_frozen(self);
 	Check_Type(str, T_STRING);
 
 	if ( (gvl_PQsetClientEncoding(conn, StringValueCStr(str))) == -1 )
@@ -4055,6 +4062,7 @@ static VALUE pgconn_external_encoding(VALUE self);
 static VALUE
 pgconn_internal_encoding_set(VALUE self, VALUE enc)
 {
+	rb_check_frozen(self);
 	if (NIL_P(enc)) {
 		pgconn_sync_set_client_encoding( self, rb_usascii_str_new_cstr("SQL_ASCII") );
 		return enc;
@@ -4109,6 +4117,7 @@ pgconn_async_set_client_encoding(VALUE self, VALUE encname)
 {
 	VALUE query_format, query;
 
+	rb_check_frozen(self);
 	Check_Type(encname, T_STRING);
 	query_format = rb_str_new_cstr("set client_encoding to '%s'");
 	query = rb_funcall(query_format, rb_intern("%"), 1, encname);
@@ -4161,6 +4170,7 @@ pgconn_set_default_encoding( VALUE self )
 	rb_encoding *enc;
 	const char *encname;
 
+	rb_check_frozen(self);
 	if (( enc = rb_default_internal_encoding() )) {
 		encname = pg_get_rb_encoding_as_pg_encoding( enc );
 		if ( pgconn_set_client_encoding_async(self, rb_str_new_cstr(encname)) != 0 )
@@ -4190,6 +4200,7 @@ pgconn_type_map_for_queries_set(VALUE self, VALUE typemap)
 	t_typemap *tm;
 	UNUSED(tm);
 
+	rb_check_frozen(self);
 	/* Check type of method param */
 	TypedData_Get_Struct(typemap, t_typemap, &pg_typemap_type, tm);
 
@@ -4230,6 +4241,7 @@ pgconn_type_map_for_results_set(VALUE self, VALUE typemap)
 	t_typemap *tm;
 	UNUSED(tm);
 
+	rb_check_frozen(self);
 	TypedData_Get_Struct(typemap, t_typemap, &pg_typemap_type, tm);
 	RB_OBJ_WRITE(self, &this->type_map_for_results, typemap);
 
@@ -4269,6 +4281,7 @@ pgconn_encoder_for_put_copy_data_set(VALUE self, VALUE encoder)
 {
 	t_pg_connection *this = pg_get_connection( self );
 
+	rb_check_frozen(self);
 	if( encoder != Qnil ){
 		t_pg_coder *co;
 		UNUSED(co);
@@ -4317,6 +4330,7 @@ pgconn_decoder_for_get_copy_data_set(VALUE self, VALUE decoder)
 {
 	t_pg_connection *this = pg_get_connection( self );
 
+	rb_check_frozen(self);
 	if( decoder != Qnil ){
 		t_pg_coder *co;
 		UNUSED(co);
@@ -4369,6 +4383,7 @@ pgconn_field_name_type_set(VALUE self, VALUE sym)
 {
 	t_pg_connection *this = pg_get_connection( self );
 
+	rb_check_frozen(self);
 	this->flags &= ~PG_RESULT_FIELD_NAMES_MASK;
 	if( sym == sym_symbol ) this->flags |= PG_RESULT_FIELD_NAMES_SYMBOL;
 	else if ( sym == sym_static_symbol ) this->flags |= PG_RESULT_FIELD_NAMES_STATIC_SYMBOL;

--- a/ext/pg_copy_coder.c
+++ b/ext/pg_copy_coder.c
@@ -55,7 +55,7 @@ static const rb_data_type_t pg_copycoder_type = {
 	},
 	&pg_coder_type,
 	0,
-	RUBY_TYPED_FREE_IMMEDIATELY | RUBY_TYPED_WB_PROTECTED,
+	RUBY_TYPED_FREE_IMMEDIATELY | RUBY_TYPED_WB_PROTECTED | PG_RUBY_TYPED_FROZEN_SHAREABLE,
 };
 
 static VALUE
@@ -96,6 +96,7 @@ static VALUE
 pg_copycoder_delimiter_set(VALUE self, VALUE delimiter)
 {
 	t_pg_copycoder *this = RTYPEDDATA_DATA(self);
+	rb_check_frozen(self);
 	StringValue(delimiter);
 	if(RSTRING_LEN(delimiter) != 1)
 		rb_raise( rb_eArgError, "delimiter size must be one byte");
@@ -127,6 +128,7 @@ static VALUE
 pg_copycoder_null_string_set(VALUE self, VALUE null_string)
 {
 	t_pg_copycoder *this = RTYPEDDATA_DATA(self);
+	rb_check_frozen(self);
 	StringValue(null_string);
 	RB_OBJ_WRITE(self, &this->null_string, null_string);
 	return null_string;
@@ -158,6 +160,7 @@ pg_copycoder_type_map_set(VALUE self, VALUE type_map)
 {
 	t_pg_copycoder *this = RTYPEDDATA_DATA( self );
 
+	rb_check_frozen(self);
 	if ( !rb_obj_is_kind_of(type_map, rb_cTypeMap) ){
 		rb_raise( rb_eTypeError, "wrong elements type %s (expected some kind of PG::TypeMap)",
 				rb_obj_classname( type_map ) );

--- a/ext/pg_record_coder.c
+++ b/ext/pg_record_coder.c
@@ -47,7 +47,7 @@ static const rb_data_type_t pg_recordcoder_type = {
 	},
 	&pg_coder_type,
 	0,
-	RUBY_TYPED_FREE_IMMEDIATELY | RUBY_TYPED_WB_PROTECTED,
+	RUBY_TYPED_FREE_IMMEDIATELY | RUBY_TYPED_WB_PROTECTED | PG_RUBY_TYPED_FROZEN_SHAREABLE,
 };
 
 static VALUE
@@ -86,6 +86,7 @@ pg_recordcoder_type_map_set(VALUE self, VALUE type_map)
 {
 	t_pg_recordcoder *this = RTYPEDDATA_DATA( self );
 
+	rb_check_frozen(self);
 	if ( !rb_obj_is_kind_of(type_map, rb_cTypeMap) ){
 		rb_raise( rb_eTypeError, "wrong elements type %s (expected some kind of PG::TypeMap)",
 				rb_obj_classname( type_map ) );

--- a/ext/pg_tuple.c
+++ b/ext/pg_tuple.c
@@ -128,7 +128,7 @@ static const rb_data_type_t pg_tuple_type = {
 		pg_compact_callback(pg_tuple_gc_compact),
 	},
 	0, 0,
-	RUBY_TYPED_FREE_IMMEDIATELY | RUBY_TYPED_WB_PROTECTED,
+	RUBY_TYPED_FREE_IMMEDIATELY | RUBY_TYPED_WB_PROTECTED | PG_RUBY_TYPED_FROZEN_SHAREABLE,
 };
 
 /*

--- a/ext/pg_type_map.c
+++ b/ext/pg_type_map.c
@@ -37,7 +37,7 @@ const rb_data_type_t pg_typemap_type = {
 	},
 	0,
 	0,
-	RUBY_TYPED_FREE_IMMEDIATELY | RUBY_TYPED_WB_PROTECTED,
+	RUBY_TYPED_FREE_IMMEDIATELY | RUBY_TYPED_WB_PROTECTED | PG_RUBY_TYPED_FROZEN_SHAREABLE,
 };
 
 VALUE rb_cTypeMap;
@@ -132,6 +132,7 @@ pg_typemap_default_type_map_set(VALUE self, VALUE typemap)
 	t_typemap *tm;
 	UNUSED(tm);
 
+	rb_check_frozen(self);
 	/* Check type of method param */
 	TypedData_Get_Struct(typemap, t_typemap, &pg_typemap_type, tm);
 	RB_OBJ_WRITE(self, &this->default_typemap, typemap);

--- a/ext/pg_type_map_all_strings.c
+++ b/ext/pg_type_map_all_strings.c
@@ -18,7 +18,7 @@ static const rb_data_type_t pg_tmas_type = {
 	},
 	&pg_typemap_type,
 	0,
-	RUBY_TYPED_FREE_IMMEDIATELY | RUBY_TYPED_WB_PROTECTED,
+	RUBY_TYPED_FREE_IMMEDIATELY | RUBY_TYPED_WB_PROTECTED | PG_RUBY_TYPED_FROZEN_SHAREABLE,
 };
 
 VALUE rb_cTypeMapAllStrings;

--- a/ext/pg_type_map_all_strings.c
+++ b/ext/pg_type_map_all_strings.c
@@ -125,6 +125,6 @@ init_pg_type_map_all_strings(void)
 	rb_cTypeMapAllStrings = rb_define_class_under( rb_mPG, "TypeMapAllStrings", rb_cTypeMap );
 	rb_define_alloc_func( rb_cTypeMapAllStrings, pg_tmas_s_allocate );
 
-	pg_typemap_all_strings = rb_funcall( rb_cTypeMapAllStrings, rb_intern("new"), 0 );
+	pg_typemap_all_strings = rb_obj_freeze( rb_funcall( rb_cTypeMapAllStrings, rb_intern("new"), 0 ));
 	rb_gc_register_address( &pg_typemap_all_strings );
 }

--- a/ext/pg_type_map_by_class.c
+++ b/ext/pg_type_map_by_class.c
@@ -157,7 +157,7 @@ static const rb_data_type_t pg_tmbk_type = {
 	},
 	&pg_typemap_type,
 	0,
-	RUBY_TYPED_FREE_IMMEDIATELY | RUBY_TYPED_WB_PROTECTED,
+	RUBY_TYPED_FREE_IMMEDIATELY | RUBY_TYPED_WB_PROTECTED | PG_RUBY_TYPED_FROZEN_SHAREABLE,
 };
 
 static VALUE
@@ -204,6 +204,8 @@ static VALUE
 pg_tmbk_aset( VALUE self, VALUE klass, VALUE coder )
 {
 	t_tmbk *this = RTYPEDDATA_DATA( self );
+
+	rb_check_frozen(self);
 
 	if(NIL_P(coder)){
 		rb_hash_delete( this->klass_to_coder, klass );

--- a/ext/pg_type_map_by_column.c
+++ b/ext/pg_type_map_by_column.c
@@ -232,7 +232,7 @@ static const rb_data_type_t pg_tmbc_type = {
 	},
 	&pg_typemap_type,
 	0,
-	RUBY_TYPED_FREE_IMMEDIATELY | RUBY_TYPED_WB_PROTECTED,
+	RUBY_TYPED_FREE_IMMEDIATELY | RUBY_TYPED_WB_PROTECTED | PG_RUBY_TYPED_FROZEN_SHAREABLE,
 };
 
 static VALUE
@@ -266,6 +266,7 @@ pg_tmbc_init(VALUE self, VALUE conv_ary)
 	t_tmbc *this;
 	int conv_ary_len;
 
+	rb_check_frozen(self);
 	Check_Type(conv_ary, T_ARRAY);
 	conv_ary_len = RARRAY_LENINT(conv_ary);
 	this = xmalloc(sizeof(t_tmbc) + sizeof(struct pg_tmbc_converter) * conv_ary_len);

--- a/ext/pg_type_map_by_oid.c
+++ b/ext/pg_type_map_by_oid.c
@@ -194,7 +194,7 @@ static const rb_data_type_t pg_tmbo_type = {
 	},
 	&pg_typemap_type,
 	0,
-	RUBY_TYPED_FREE_IMMEDIATELY | RUBY_TYPED_WB_PROTECTED,
+	RUBY_TYPED_FREE_IMMEDIATELY | RUBY_TYPED_WB_PROTECTED | PG_RUBY_TYPED_FROZEN_SHAREABLE,
 };
 
 static VALUE
@@ -242,6 +242,7 @@ pg_tmbo_add_coder( VALUE self, VALUE coder )
 	t_pg_coder *p_coder;
 	struct pg_tmbo_oid_cache_entry *p_ce;
 
+	rb_check_frozen(self);
 	TypedData_Get_Struct(coder, t_pg_coder, &pg_coder_type, p_coder);
 
 	if( p_coder->format < 0 || p_coder->format > 1 )
@@ -276,6 +277,7 @@ pg_tmbo_rm_coder( VALUE self, VALUE format, VALUE oid )
 	int i_format = NUM2INT(format);
 	struct pg_tmbo_oid_cache_entry *p_ce;
 
+	rb_check_frozen(self);
 	if( i_format < 0 || i_format > 1 )
 		rb_raise(rb_eArgError, "invalid format code %d", i_format);
 
@@ -318,6 +320,7 @@ static VALUE
 pg_tmbo_max_rows_for_online_lookup_set( VALUE self, VALUE value )
 {
 	t_tmbo *this = RTYPEDDATA_DATA( self );
+	rb_check_frozen(self);
 	this->max_rows_for_online_lookup = NUM2INT(value);
 	return value;
 }

--- a/ext/pg_type_map_in_ruby.c
+++ b/ext/pg_type_map_in_ruby.c
@@ -44,7 +44,7 @@ static const rb_data_type_t pg_tmir_type = {
 	},
 	&pg_typemap_type,
 	0,
-	RUBY_TYPED_FREE_IMMEDIATELY | RUBY_TYPED_WB_PROTECTED,
+	RUBY_TYPED_FREE_IMMEDIATELY | RUBY_TYPED_WB_PROTECTED | PG_RUBY_TYPED_FROZEN_SHAREABLE,
 };
 
 /*

--- a/lib/pg.rb
+++ b/lib/pg.rb
@@ -63,6 +63,15 @@ module PG
 		Connection.new( *args, &block )
 	end
 
+	if defined?(Ractor.make_shareable)
+		def self.make_shareable(obj)
+			Ractor.make_shareable(obj)
+		end
+	else
+		def self.make_shareable(obj)
+			obj.freeze
+		end
+	end
 
 	module BinaryDecoder
 		%i[ TimestampUtc TimestampUtcToLocal TimestampLocal ].each do |klass|

--- a/lib/pg/basic_type_map_for_queries.rb
+++ b/lib/pg/basic_type_map_for_queries.rb
@@ -53,10 +53,12 @@ class PG::BasicTypeMapForQueries < PG::TypeMapByClass
 		@coder_maps = build_coder_maps(connection_or_coder_maps, registry: registry)
 		@array_encoders_by_klass = array_encoders_by_klass
 		@encode_array_as = :array
-		@if_undefined = if_undefined || proc { |oid_name, format|
-			raise UndefinedEncoder, "no encoder defined for type #{oid_name.inspect} format #{format}"
-		}
+		@if_undefined = if_undefined || method(:raise_undefined_type).to_proc
 		init_encoders
+	end
+
+	private def raise_undefined_type(oid_name, format)
+		raise UndefinedEncoder, "no encoder defined for type #{oid_name.inspect} format #{format}"
 	end
 
 	# Change the mechanism that is used to encode ruby array values

--- a/lib/pg/basic_type_map_for_queries.rb
+++ b/lib/pg/basic_type_map_for_queries.rb
@@ -166,7 +166,7 @@ class PG::BasicTypeMapForQueries < PG::TypeMapByClass
 				@textarray_encoder
 	end
 
-	DEFAULT_TYPE_MAP = {
+	DEFAULT_TYPE_MAP = PG.make_shareable({
 		TrueClass => [1, 'bool', 'bool'],
 		FalseClass => [1, 'bool', 'bool'],
 		# We use text format and no type OID for numbers, because setting the OID can lead
@@ -181,9 +181,9 @@ class PG::BasicTypeMapForQueries < PG::TypeMapByClass
 		Hash => [0, 'json'],
 		Array => :get_array_type,
 		BinaryData => [1, 'bytea'],
-	}
+	})
 
-	DEFAULT_ARRAY_TYPE_MAP = {
+	DEFAULT_ARRAY_TYPE_MAP = PG.make_shareable({
 		TrueClass => [0, '_bool'],
 		FalseClass => [0, '_bool'],
 		Integer => [0, '_int8'],
@@ -192,6 +192,6 @@ class PG::BasicTypeMapForQueries < PG::TypeMapByClass
 		BigDecimal => [0, '_numeric'],
 		Time => [0, '_timestamptz'],
 		IPAddr => [0, '_inet'],
-	}
+	})
 
 end

--- a/lib/pg/basic_type_registry.rb
+++ b/lib/pg/basic_type_registry.rb
@@ -294,14 +294,4 @@ class PG::BasicTypeRegistry
 
 	# @private
 	DEFAULT_TYPE_REGISTRY = PG.make_shareable(PG::BasicTypeRegistry.new.register_default_types)
-
-	# Delegate class method calls to DEFAULT_TYPE_REGISTRY
-	class << self
-		%i[ register_coder register_type alias_type ].each do |meth|
-			define_method(meth) do |*args|
-				warn "PG::BasicTypeRegistry.#{meth} is deprecated. Please use your own instance by PG::BasicTypeRegistry.new instead!"
-				DEFAULT_TYPE_REGISTRY.send(meth, *args)
-			end
-		end
-	end
 end

--- a/lib/pg/basic_type_registry.rb
+++ b/lib/pg/basic_type_registry.rb
@@ -39,7 +39,7 @@ class PG::BasicTypeRegistry
 			oid
 			bool
 			date timestamp timestamptz
-		].inject({}){|h,e| h[e] = true; h }
+		].inject({}){|h,e| h[e] = true; h }.freeze
 
 		def initialize(result, coders_by_name, format, arraycoder)
 			coder_map = {}
@@ -52,7 +52,7 @@ class PG::BasicTypeRegistry
 				coder.oid = row['oid'].to_i
 				coder.name = row['typname']
 				coder.format = format
-				coder_map[coder.oid] = coder
+				coder_map[coder.oid] = coder.freeze
 			end
 
 			if arraycoder
@@ -67,13 +67,14 @@ class PG::BasicTypeRegistry
 					coder.format = format
 					coder.elements_type = elements_coder
 					coder.needs_quotation = !DONT_QUOTE_TYPES[elements_coder.name]
-					coder_map[coder.oid] = coder
+					coder_map[coder.oid] = coder.freeze
 				end
 			end
 
-			@coders = coder_map.values
-			@coders_by_name = @coders.inject({}){|h, t| h[t.name] = t; h }
-			@coders_by_oid = @coders.inject({}){|h, t| h[t.oid] = t; h }
+			@coders = coder_map.values.freeze
+			@coders_by_name = @coders.inject({}){|h, t| h[t.name] = t; h }.freeze
+			@coders_by_oid = @coders.inject({}){|h, t| h[t.oid] = t; h }.freeze
+			freeze
 		end
 
 		attr_reader :coders
@@ -117,6 +118,11 @@ class PG::BasicTypeRegistry
 				JOIN pg_proc as ti ON ti.oid = t.typinput
 			SQL
 
+			init_maps(registry, result.freeze)
+			freeze
+		end
+
+		private def init_maps(registry, result)
 			@maps = [
 				[0, :encoder, PG::TextEncoder::Array],
 				[0, :decoder, PG::TextDecoder::Array],
@@ -127,9 +133,9 @@ class PG::BasicTypeRegistry
 				h[format] ||= {}
 				h[format][direction] = CoderMap.new(result, coders, format, arraycoder)
 				h
-			end
+			end.each{|h| h.freeze }.freeze
 
-			@typenames_by_oid = result.inject({}){|h, t| h[t['oid'].to_i] = t['typname']; h }
+			@typenames_by_oid = result.inject({}){|h, t| h[t['oid'].to_i] = t['typname']; h }.freeze
 		end
 
 		def each_format(direction)
@@ -142,8 +148,8 @@ class PG::BasicTypeRegistry
 	end
 
 	module Checker
-		ValidFormats = { 0 => true, 1 => true }
-		ValidDirections = { :encoder => true, :decoder => true }
+		ValidFormats = { 0 => true, 1 => true }.freeze
+		ValidDirections = { :encoder => true, :decoder => true }.freeze
 
 		protected def check_format_and_direction(format, direction)
 			raise(ArgumentError, "Invalid format value %p" % format) unless ValidFormats[format]
@@ -155,7 +161,7 @@ class PG::BasicTypeRegistry
 				raise ArgumentError, "registry argument must be given to CoderMapsBundle" if registry
 				conn_or_maps
 			else
-				PG::BasicTypeRegistry::CoderMapsBundle.new(conn_or_maps, registry: registry)
+				PG::BasicTypeRegistry::CoderMapsBundle.new(conn_or_maps, registry: registry).freeze
 			end
 		end
 	end
@@ -192,8 +198,8 @@ class PG::BasicTypeRegistry
 	# +name+ must correspond to the +typname+ column in the +pg_type+ table.
 	# +format+ can be 0 for text format and 1 for binary.
 	def register_type(format, name, encoder_class, decoder_class)
-		register_coder(encoder_class.new(name: name, format: format)) if encoder_class
-		register_coder(decoder_class.new(name: name, format: format)) if decoder_class
+		register_coder(encoder_class.new(name: name, format: format).freeze) if encoder_class
+		register_coder(decoder_class.new(name: name, format: format).freeze) if decoder_class
 		self
 	end
 
@@ -287,7 +293,7 @@ class PG::BasicTypeRegistry
 	alias define_default_types register_default_types
 
 	# @private
-	DEFAULT_TYPE_REGISTRY = PG::BasicTypeRegistry.new.register_default_types
+	DEFAULT_TYPE_REGISTRY = PG.make_shareable(PG::BasicTypeRegistry.new.register_default_types)
 
 	# Delegate class method calls to DEFAULT_TYPE_REGISTRY
 	class << self

--- a/lib/pg/connection.rb
+++ b/lib/pg/connection.rb
@@ -30,7 +30,7 @@ require 'socket'
 class PG::Connection
 
 	# The order the options are passed to the ::connect method.
-	CONNECT_ARGUMENT_ORDER = %w[host port options tty dbname user password]
+	CONNECT_ARGUMENT_ORDER = %w[host port options tty dbname user password].freeze
 
 
 	### Quote a single +value+ for use in a connection-parameter string.
@@ -44,6 +44,9 @@ class PG::Connection
 	def self.connect_hash_to_string( hash )
 		hash.map { |k,v| "#{k}=#{quote_connstr(v)}" }.join( ' ' )
 	end
+
+	# Shareable program name for Ractor
+	PROGRAM_NAME = $PROGRAM_NAME
 
 	# Parse the connection +args+ into a connection-parameter string.
 	# See PG::Connection.new for valid arguments.
@@ -86,7 +89,7 @@ class PG::Connection
 		iopts.merge!( hash_arg )
 
 		if !iopts[:fallback_application_name]
-			iopts[:fallback_application_name] = $0.sub( /^(.{30}).{4,}(.{30})$/ ){ $1+"..."+$2 }
+			iopts[:fallback_application_name] = PROGRAM_NAME.sub( /^(.{30}).{4,}(.{30})$/ ){ $1+"..."+$2 }
 		end
 
 		return connect_hash_to_string(iopts)

--- a/lib/pg/connection.rb
+++ b/lib/pg/connection.rb
@@ -46,7 +46,7 @@ class PG::Connection
 	end
 
 	# Shareable program name for Ractor
-	PROGRAM_NAME = $PROGRAM_NAME
+	PROGRAM_NAME = $PROGRAM_NAME.dup.freeze
 
 	# Parse the connection +args+ into a connection-parameter string.
 	# See PG::Connection.new for valid arguments.
@@ -821,23 +821,23 @@ class PG::Connection
 		end
 		alias async_ping ping
 
-		REDIRECT_CLASS_METHODS = {
+		REDIRECT_CLASS_METHODS = PG.make_shareable({
 			:new => [:async_connect, :sync_connect],
 			:connect => [:async_connect, :sync_connect],
 			:open => [:async_connect, :sync_connect],
 			:setdb => [:async_connect, :sync_connect],
 			:setdblogin => [:async_connect, :sync_connect],
 			:ping => [:async_ping, :sync_ping],
-		}
+		})
 
 		# These methods are affected by PQsetnonblocking
-		REDIRECT_SEND_METHODS = {
+		REDIRECT_SEND_METHODS = PG.make_shareable({
 			:isnonblocking => [:async_isnonblocking, :sync_isnonblocking],
 			:nonblocking? => [:async_isnonblocking, :sync_isnonblocking],
 			:put_copy_data => [:async_put_copy_data, :sync_put_copy_data],
 			:put_copy_end => [:async_put_copy_end, :sync_put_copy_end],
 			:flush => [:async_flush, :sync_flush],
-		}
+		})
 		REDIRECT_METHODS = {
 			:exec => [:async_exec, :sync_exec],
 			:query => [:async_exec, :sync_exec],
@@ -861,6 +861,7 @@ class PG::Connection
 				:encrypt_password => [:async_encrypt_password, :sync_encrypt_password],
 			})
 		end
+		PG.make_shareable(REDIRECT_METHODS)
 
 		def async_send_api=(enable)
 			REDIRECT_SEND_METHODS.each do |ali, (async, sync)|

--- a/spec/helpers.rb
+++ b/spec/helpers.rb
@@ -700,6 +700,7 @@ RSpec.configure do |config|
 	config.filter_run_excluding( :scheduler ) if RUBY_VERSION < "3.0" || (RUBY_PLATFORM =~ /mingw|mswin/ && RUBY_VERSION < "3.1") || !Fiber.respond_to?(:scheduler)
 	config.filter_run_excluding( :scheduler_address_resolve ) if RUBY_VERSION < "3.1"
 	config.filter_run_excluding( :ipv6 ) if Addrinfo.getaddrinfo("localhost", nil, nil, :STREAM).size < 2
+	config.filter_run_excluding( :ractor ) unless defined?(Ractor)
 
 	### Automatically set up and tear down the database
 	config.before(:suite) do |*args|

--- a/spec/pg/basic_type_map_for_queries_spec.rb
+++ b/spec/pg/basic_type_map_for_queries_spec.rb
@@ -10,11 +10,15 @@ describe 'Basic type mapping' do
 
 	describe PG::BasicTypeMapForQueries do
 		let!(:basic_type_mapping) do
-			PG::BasicTypeMapForQueries.new @conn
+			PG::BasicTypeMapForQueries.new(@conn).freeze
+		end
+
+		let!(:basic_type_mapping_writable) do
+			PG::BasicTypeMapForQueries.new(@conn)
 		end
 
 		it "can be initialized with a CoderMapsBundle instead of a connection" do
-			maps = PG::BasicTypeRegistry::CoderMapsBundle.new(@conn)
+			maps = PG::BasicTypeRegistry::CoderMapsBundle.new(@conn).freeze
 			tm = PG::BasicTypeMapForQueries.new(maps)
 			expect( tm[Integer] ).to be_kind_of(PG::TextEncoder::Integer)
 		end
@@ -22,13 +26,13 @@ describe 'Basic type mapping' do
 		it "can be initialized with a custom type registry" do
 			regi = PG::BasicTypeRegistry.new
 			regi.register_type 0, 'int8', PG::BinaryEncoder::Int8, nil
-			tm = PG::BasicTypeMapForQueries.new(@conn, registry: regi, if_undefined: proc{})
+			tm = PG::BasicTypeMapForQueries.new(@conn, registry: regi, if_undefined: proc{}).freeze
 			res = @conn.exec_params( "SELECT $1::text", [0x3031323334353637], 0, tm )
 			expect( res.values ).to eq( [["01234567"]] )
 		end
 
 		it "can take a Proc and nitify about undefined types" do
-			regi = PG::BasicTypeRegistry.new
+			regi = PG::BasicTypeRegistry.new.freeze
 			args = []
 			pr = proc { |*a| args << a }
 			PG::BasicTypeMapForQueries.new(@conn, registry: regi, if_undefined: pr)
@@ -36,10 +40,14 @@ describe 'Basic type mapping' do
 		end
 
 		it "raises UndefinedEncoder for undefined types" do
-			regi = PG::BasicTypeRegistry.new
+			regi = PG::BasicTypeRegistry.new.freeze
 			expect do
 				PG::BasicTypeMapForQueries.new(@conn, registry: regi, if_undefined: nil)
 			end.to raise_error(PG::BasicTypeMapForQueries::UndefinedEncoder)
+		end
+
+		it "should be shareable for Ractor", :ractor do
+			Ractor.make_shareable(basic_type_mapping)
 		end
 
 		#
@@ -118,13 +126,13 @@ describe 'Basic type mapping' do
 		end
 
 		it "should do array-as-json encoding" do
-			basic_type_mapping.encode_array_as = :json
-			expect( basic_type_mapping.encode_array_as).to eq(:json)
+			basic_type_mapping_writable.encode_array_as = :json
+			expect( basic_type_mapping_writable.encode_array_as).to eq(:json)
 
 			res = @conn.exec_params( "SELECT $1::JSON, $2::JSON", [
 					[1, {a: 5}, true, ["a", 2], [3.4, nil]],
 					['/,"'.gsub("/", "\\"), nil, 'abcäöü'],
-				], nil, basic_type_mapping )
+				], nil, basic_type_mapping_writable )
 
 			expect( res.values ).to eq( [[
 					'[1,{"a":5},true,["a",2],[3.4,null]]',
@@ -160,14 +168,14 @@ describe 'Basic type mapping' do
 			end
 
 			it "should do array-as-record encoding" do
-				basic_type_mapping.encode_array_as = :record
-				expect( basic_type_mapping.encode_array_as).to eq(:record)
+				basic_type_mapping_writable.encode_array_as = :record
+				expect( basic_type_mapping_writable.encode_array_as).to eq(:record)
 
 				res = @conn.exec_params( "SELECT $1::test_record1, $2::test_record2, $3::text", [
 						[5, 3.4, "txt"],
 				    [1, [2, 4.5, "bcd"]],
 				    [4, 5, 6],
-					], nil, basic_type_mapping )
+					], nil, basic_type_mapping_writable )
 
 				expect( res.values ).to eq( [[
 						'(5,3.4,txt)',
@@ -221,7 +229,7 @@ describe 'Basic type mapping' do
 
 		it "should take BinaryData for bytea columns" do
 			@conn.exec("CREATE TEMP TABLE IF NOT EXISTS bytea_test (data bytea)")
-			bd = PG::BasicTypeMapForQueries::BinaryData.new("ab\xff\0cd")
+			bd = PG::BasicTypeMapForQueries::BinaryData.new("ab\xff\0cd").freeze
 			res = @conn.exec_params("INSERT INTO bytea_test (data) VALUES ($1) RETURNING data", [bd], nil, basic_type_mapping)
 
 			expect( res.to_a ).to eq([{"data" => "\\x6162ff006364"}])

--- a/spec/pg/basic_type_map_for_results_spec.rb
+++ b/spec/pg/basic_type_map_for_results_spec.rb
@@ -48,7 +48,7 @@ describe 'Basic type mapping' do
 			vals = Ractor.new(@conninfo) do |conninfo|
 				conn = PG.connect(conninfo)
 				res = conn.exec( "SELECT 1, 'a', 2.0::FLOAT, TRUE, '2013-06-30'::DATE" )
-				btm = PG::BasicTypeMapForResults.new(@conn)
+				btm = PG::BasicTypeMapForResults.new(conn)
 				res.map_types!(btm).values
 			ensure
 				conn&.finish

--- a/spec/pg/basic_type_registry_spec.rb
+++ b/spec/pg/basic_type_registry_spec.rb
@@ -62,37 +62,5 @@ describe 'Basic type mapping' do
 			expect{ regi.coders_for 0, :coder }.to raise_error( ArgumentError )
 			expect{ regi.coders_for 2, :encoder }.to raise_error( ArgumentError )
 		end
-
-		context "class methods" do
-			let!(:regi){ PG::BasicTypeRegistry::DEFAULT_TYPE_REGISTRY }
-
-			it "can register_type" do
-				expect do
-					PG::BasicTypeRegistry.register_type(1, 'testtype1', PG::BinaryEncoder::Int8, PG::BinaryDecoder::Integer)
-				end.to output(/deprecated/).to_stderr
-
-				expect( regi.coders_for(1, :encoder)['testtype1'] ).to be_kind_of(PG::BinaryEncoder::Int8)
-				expect( regi.coders_for(1, :decoder)['testtype1'] ).to be_kind_of(PG::BinaryDecoder::Integer)
-			end
-
-			it "can alias_type" do
-				expect do
-					PG::BasicTypeRegistry.alias_type(1, 'testtype2', 'int4')
-				end.to output(/deprecated/).to_stderr
-
-				expect( regi.coders_for(1, :encoder)['testtype2'] ).to be_kind_of(PG::BinaryEncoder::Int4)
-				expect( regi.coders_for(1, :decoder)['testtype2'] ).to be_kind_of(PG::BinaryDecoder::Integer)
-			end
-
-			it "can register_coder" do
-				enco = PG::BinaryEncoder::Int8.new(name: 'testtype3')
-				expect do
-					PG::BasicTypeRegistry.register_coder(enco)
-				end.to output(/deprecated/).to_stderr
-
-				expect( regi.coders_for(1, :encoder)['testtype3'] ).to be(enco)
-				expect( regi.coders_for(1, :decoder)['testtype3'] ).to be_nil
-			end
-		end
 	end
 end

--- a/spec/pg/basic_type_registry_spec.rb
+++ b/spec/pg/basic_type_registry_spec.rb
@@ -5,6 +5,10 @@ require_relative '../helpers'
 
 describe 'Basic type mapping' do
 	describe PG::BasicTypeRegistry do
+		it "should be shareable for Ractor", :ractor do
+			Ractor.make_shareable(PG::BasicTypeRegistry.new.register_default_types)
+		end
+
 		it "can register_type" do
 			regi = PG::BasicTypeRegistry.new
 			res = regi.register_type(1, 'int4', PG::BinaryEncoder::Int8, PG::BinaryDecoder::Integer)

--- a/spec/pg/exceptions_spec.rb
+++ b/spec/pg/exceptions_spec.rb
@@ -1,0 +1,46 @@
+# -*- rspec -*-
+# encoding: utf-8
+
+require_relative '../helpers'
+
+require 'pg'
+
+describe PG::Error do
+
+	it "does have hierarchical error classes" do
+		expect( PG::UndefinedTable.ancestors[0,4] ).to eq([
+				PG::UndefinedTable,
+				PG::SyntaxErrorOrAccessRuleViolation,
+				PG::ServerError,
+		        PG::Error
+		        ])
+
+		expect( PG::InvalidSchemaName.ancestors[0,3] ).to eq([
+				PG::InvalidSchemaName,
+				PG::ServerError,
+		        PG::Error
+		        ])
+	end
+
+	it "can be used to raise errors without text" do
+		expect{ raise PG::InvalidTextRepresentation }.to raise_error(PG::InvalidTextRepresentation)
+	end
+
+	it "should be delivered by Ractor", :ractor do
+		r = Ractor.new(@conninfo) do |conninfo|
+			conn = PG.connect(conninfo)
+			conn.exec("SELECT 0/0")
+		ensure
+			conn&.finish
+		end
+
+		begin
+			r.take
+		rescue Exception => err
+		end
+
+		expect( err.cause ).to be_kind_of(PG::Error)
+		expect{ raise err.cause }.to raise_error(PG::DivisionByZero, /division by zero/)
+		expect{ raise err }.to raise_error(Ractor::RemoteError)
+	end
+end

--- a/spec/pg/result_spec.rb
+++ b/spec/pg/result_spec.rb
@@ -20,6 +20,18 @@ describe PG::Result do
 		expect{ res.res_status(1,2) }.to raise_error(ArgumentError)
 	end
 
+	it "should deny changes when frozen" do
+		res = @conn.exec("SELECT 1").freeze
+		expect{ res.type_map = PG::TypeMapAllStrings.new }.to raise_error(FrozenError)
+		expect{ res.field_name_type = :symbol  }.to raise_error(FrozenError)
+		expect{ res.clear }.to raise_error(FrozenError)
+	end
+
+	it "should be shareable for Ractor", :ractor do
+		res = @conn.exec("SELECT 1")
+		Ractor.make_shareable(res)
+	end
+
 	describe :field_name_type do
 		let!(:res) { @conn.exec('SELECT 1 AS a, 2 AS "B"') }
 
@@ -277,6 +289,15 @@ describe PG::Result do
 					# No-op
 				end
 			}.to raise_error(PG::QueryCanceled, /statement timeout/)
+		end
+
+		it "should deny streaming when frozen" do
+			@conn.send_query( "SELECT 1" )
+			@conn.set_single_row_mode
+			res = @conn.get_result.freeze
+			expect{
+				res.stream_each_row
+			}.to raise_error(FrozenError)
 		end
 	end
 

--- a/spec/pg/result_spec.rb
+++ b/spec/pg/result_spec.rb
@@ -32,6 +32,19 @@ describe PG::Result do
 		Ractor.make_shareable(res)
 	end
 
+	it "should be usable with Ractor", :ractor do
+		res = Ractor.new(@conninfo) do |conninfo|
+			conn = PG.connect(conninfo)
+			conn.exec("SELECT 123 as col")
+		ensure
+			conn&.finish
+		end.take
+
+		expect( res ).to be_kind_of( PG::Result )
+		expect( res.fields ).to eq( ["col"] )
+		expect( res.values ).to eq( [["123"]] )
+	end
+
 	describe :field_name_type do
 		let!(:res) { @conn.exec('SELECT 1 AS a, 2 AS "B"') }
 

--- a/spec/pg/scheduler_spec.rb
+++ b/spec/pg/scheduler_spec.rb
@@ -3,6 +3,9 @@
 
 require_relative '../helpers'
 
+# Work around ruby bug: https://bugs.ruby-lang.org/issues/19562
+''.encode(Encoding::ISO8859_3)
+
 $scheduler_timeout = false
 
 context "with a Fiber scheduler", :scheduler do

--- a/spec/pg/type_map_spec.rb
+++ b/spec/pg/type_map_spec.rb
@@ -7,7 +7,7 @@ require 'pg'
 
 
 describe PG::TypeMap do
-	let!(:tm){ PG::TypeMap.new }
+	let!(:tm){ PG::TypeMap.new.freeze }
 
 	it "should give account about memory usage" do
 		expect( ObjectSpace.memsize_of(tm) ).to be > DATA_OBJ_MEMSIZE
@@ -23,4 +23,9 @@ describe PG::TypeMap do
 		res = @conn.exec( "SELECT 1" )
 		expect{ res.map_types!(tm) }.to raise_error(NotImplementedError, /not suitable to map result values/)
 	end
+
+	it "should be shareable for Ractor", :ractor do
+		Ractor.make_shareable(tm)
+	end
+
 end

--- a/spec/pg/type_spec.rb
+++ b/spec/pg/type_spec.rb
@@ -559,6 +559,18 @@ describe "PG::Type derivations" do
 			expect( t.name ).to eq( "abcä" )
 		end
 
+		it "should deny changes when frozen" do
+			t = PG::TextEncoder::String.new.freeze
+			expect{ t.format = 1 }.to raise_error(FrozenError)
+			expect{ t.oid = 0  }.to raise_error(FrozenError)
+			expect{ t.name = "x" }.to raise_error(FrozenError)
+		end
+
+		it "should be shareable", :ractor do
+			t = PG::TextEncoder::String.new.freeze
+			Ractor.make_shareable(t)
+		end
+
 		it "should give account about memory usage" do
 			expect( ObjectSpace.memsize_of(textenc_int) ).to be > DATA_OBJ_MEMSIZE
 			expect( ObjectSpace.memsize_of(binarydec_integer) ).to be > DATA_OBJ_MEMSIZE
@@ -885,6 +897,21 @@ describe "PG::Type derivations" do
 				expect( t.elements_type ).to be_nil
 			end
 
+		it "should deny changes when frozen" do
+			t = PG::TextEncoder::Array.new.freeze
+			expect{ t.format = 1 }.to raise_error(FrozenError)
+			expect{ t.oid = 0  }.to raise_error(FrozenError)
+			expect{ t.name = "x" }.to raise_error(FrozenError)
+			expect{ t.needs_quotation = true }.to raise_error(FrozenError)
+			expect{ t.delimiter = ","  }.to raise_error(FrozenError)
+			expect{ t.elements_type = nil }.to raise_error(FrozenError)
+		end
+
+		it "should be shareable", :ractor do
+			t = PG::TextEncoder::Array.new.freeze
+			Ractor.make_shareable(t)
+		end
+
 		it "should give account about memory usage" do
 			expect( ObjectSpace.memsize_of(textenc_int_array) ).to be > DATA_OBJ_MEMSIZE
 			expect( ObjectSpace.memsize_of(textdec_bytea_array) ).to be > DATA_OBJ_MEMSIZE
@@ -996,6 +1023,21 @@ describe "PG::Type derivations" do
 			context "with default typemap" do
 				let!(:encoder) do
 					PG::TextEncoder::CopyRow.new
+				end
+
+				it "should deny changes when frozen" do
+					t = PG::TextEncoder::CopyRow.new.freeze
+					expect{ t.format = 1 }.to raise_error(FrozenError)
+					expect{ t.oid = 0  }.to raise_error(FrozenError)
+					expect{ t.name = "x" }.to raise_error(FrozenError)
+					expect{ t.type_map = nil }.to raise_error(FrozenError)
+					expect{ t.delimiter = ","  }.to raise_error(FrozenError)
+					expect{ t.null_string = "NULL" }.to raise_error(FrozenError)
+				end
+
+				it "should be shareable", :ractor do
+					t = PG::TextEncoder::CopyRow.new.freeze
+					Ractor.make_shareable(t)
 				end
 
 				it "should give account about memory usage" do
@@ -1222,6 +1264,19 @@ describe "PG::Type derivations" do
 			context "with default typemap" do
 				let!(:encoder) do
 					PG::TextEncoder::Record.new
+				end
+
+				it "should deny changes when frozen" do
+					t = PG::TextEncoder::Record.new.freeze
+					expect{ t.format = 1 }.to raise_error(FrozenError)
+					expect{ t.oid = 0  }.to raise_error(FrozenError)
+					expect{ t.name = "x" }.to raise_error(FrozenError)
+					expect{ t.type_map = nil }.to raise_error(FrozenError)
+				end
+
+				it "should be shareable", :ractor do
+					t = PG::TextEncoder::Record.new.freeze
+					Ractor.make_shareable(t)
 				end
 
 				it "should give account about memory usage" do

--- a/spec/pg/type_spec.rb
+++ b/spec/pg/type_spec.rb
@@ -566,7 +566,7 @@ describe "PG::Type derivations" do
 			expect{ t.name = "x" }.to raise_error(FrozenError)
 		end
 
-		it "should be shareable", :ractor do
+		it "should be shareable for Ractor", :ractor do
 			t = PG::TextEncoder::String.new.freeze
 			Ractor.make_shareable(t)
 		end
@@ -907,7 +907,7 @@ describe "PG::Type derivations" do
 			expect{ t.elements_type = nil }.to raise_error(FrozenError)
 		end
 
-		it "should be shareable", :ractor do
+		it "should be shareable for Ractor", :ractor do
 			t = PG::TextEncoder::Array.new.freeze
 			Ractor.make_shareable(t)
 		end
@@ -1035,7 +1035,7 @@ describe "PG::Type derivations" do
 					expect{ t.null_string = "NULL" }.to raise_error(FrozenError)
 				end
 
-				it "should be shareable", :ractor do
+				it "should be shareable for Ractor", :ractor do
 					t = PG::TextEncoder::CopyRow.new.freeze
 					Ractor.make_shareable(t)
 				end
@@ -1274,7 +1274,7 @@ describe "PG::Type derivations" do
 					expect{ t.type_map = nil }.to raise_error(FrozenError)
 				end
 
-				it "should be shareable", :ractor do
+				it "should be shareable for Ractor", :ractor do
 					t = PG::TextEncoder::Record.new.freeze
 					Ractor.make_shareable(t)
 				end

--- a/spec/pg_spec.rb
+++ b/spec/pg_spec.rb
@@ -38,25 +38,6 @@ describe PG do
 		expect( PG ).to be_threadsafe()
 	end
 
-	it "does have hierarchical error classes" do
-		expect( PG::UndefinedTable.ancestors[0,4] ).to eq([
-				PG::UndefinedTable,
-				PG::SyntaxErrorOrAccessRuleViolation,
-				PG::ServerError,
-		        PG::Error
-		        ])
-
-		expect( PG::InvalidSchemaName.ancestors[0,3] ).to eq([
-				PG::InvalidSchemaName,
-				PG::ServerError,
-		        PG::Error
-		        ])
-	end
-
-	it "can be used to raise errors without text" do
-		expect{ raise PG::InvalidTextRepresentation }.to raise_error(PG::InvalidTextRepresentation)
-	end
-
 	it "tells about the libpq library path" do
 		expect( PG::POSTGRESQL_LIB_PATH ).to include("/")
 	end


### PR DESCRIPTION
This implements Ractor compatibility.

* Pg is now fully compatible with Ractor introduced in Ruby-3.0
* All type en/decoders and type maps are shareable between ractors if they are made frozen by `Ractor.make_shareable`.
* Also frozen PG::Result and PG::Tuple objects can be shared.
* All frozen objects (except PG::Connection) can still be used to do communication with the PostgreSQL server or to read retrieved data.

* PG::Connection is not shareable and must be created within each Ractor to establish a dedicated connection.


Fixes #400