### PR TITLE
Don't overwrite flags of timestamp coders

### DIFF
--- a/lib/pg/binary_decoder/timestamp.rb
+++ b/lib/pg/binary_decoder/timestamp.rb
@@ -7,19 +7,19 @@ module PG
 		class TimestampUtc < Timestamp
 			def initialize(hash={}, **kwargs)
 				warn "PG::Coder.new(hash) is deprecated. Please use keyword arguments instead! Called from #{caller.first}" unless hash.empty?
-				super(flags: PG::Coder::TIMESTAMP_DB_UTC | PG::Coder::TIMESTAMP_APP_UTC, **hash, **kwargs)
+				super(**hash, **kwargs, flags: PG::Coder::TIMESTAMP_DB_UTC | PG::Coder::TIMESTAMP_APP_UTC)
 			end
 		end
 		class TimestampUtcToLocal < Timestamp
 			def initialize(hash={}, **kwargs)
 				warn "PG::Coder.new(hash) is deprecated. Please use keyword arguments instead! Called from #{caller.first}" unless hash.empty?
-				super(flags: PG::Coder::TIMESTAMP_DB_UTC | PG::Coder::TIMESTAMP_APP_LOCAL, **hash, **kwargs)
+				super(**hash, **kwargs, flags: PG::Coder::TIMESTAMP_DB_UTC | PG::Coder::TIMESTAMP_APP_LOCAL)
 			end
 		end
 		class TimestampLocal < Timestamp
 			def initialize(hash={}, **kwargs)
 				warn "PG::Coder.new(hash) is deprecated. Please use keyword arguments instead! Called from #{caller.first}" unless hash.empty?
-				super(flags: PG::Coder::TIMESTAMP_DB_LOCAL | PG::Coder::TIMESTAMP_APP_LOCAL, **hash, **kwargs)
+				super(**hash, **kwargs, flags: PG::Coder::TIMESTAMP_DB_LOCAL | PG::Coder::TIMESTAMP_APP_LOCAL)
 			end
 		end
 	end

--- a/lib/pg/binary_encoder/timestamp.rb
+++ b/lib/pg/binary_encoder/timestamp.rb
@@ -7,13 +7,13 @@ module PG
 		class TimestampUtc < Timestamp
 			def initialize(hash={}, **kwargs)
 				warn "PG::Coder.new(hash) is deprecated. Please use keyword arguments instead! Called from #{caller.first}" unless hash.empty?
-				super(flags: PG::Coder::TIMESTAMP_DB_UTC, **hash, **kwargs)
+				super(**hash, **kwargs, flags: PG::Coder::TIMESTAMP_DB_UTC)
 			end
 		end
 		class TimestampLocal < Timestamp
 			def initialize(hash={}, **kwargs)
 				warn "PG::Coder.new(hash) is deprecated. Please use keyword arguments instead! Called from #{caller.first}" unless hash.empty?
-				super(flags: PG::Coder::TIMESTAMP_DB_LOCAL, **hash, **kwargs)
+				super(**hash, **kwargs, flags: PG::Coder::TIMESTAMP_DB_LOCAL)
 			end
 		end
 	end

--- a/lib/pg/text_decoder/timestamp.rb
+++ b/lib/pg/text_decoder/timestamp.rb
@@ -7,19 +7,19 @@ module PG
 		class TimestampUtc < Timestamp
 			def initialize(hash={}, **kwargs)
 				warn "PG::Coder.new(hash) is deprecated. Please use keyword arguments instead! Called from #{caller.first}" unless hash.empty?
-				super(flags: PG::Coder::TIMESTAMP_DB_UTC | PG::Coder::TIMESTAMP_APP_UTC, **hash, **kwargs)
+				super(**hash, **kwargs, flags: PG::Coder::TIMESTAMP_DB_UTC | PG::Coder::TIMESTAMP_APP_UTC)
 			end
 		end
 		class TimestampUtcToLocal < Timestamp
 			def initialize(hash={}, **kwargs)
 				warn "PG::Coder.new(hash) is deprecated. Please use keyword arguments instead! Called from #{caller.first}" unless hash.empty?
-				super(flags: PG::Coder::TIMESTAMP_DB_UTC | PG::Coder::TIMESTAMP_APP_LOCAL, **hash, **kwargs)
+				super(**hash, **kwargs, flags: PG::Coder::TIMESTAMP_DB_UTC | PG::Coder::TIMESTAMP_APP_LOCAL)
 			end
 		end
 		class TimestampLocal < Timestamp
 			def initialize(hash={}, **kwargs)
 				warn "PG::Coder.new(hash) is deprecated. Please use keyword arguments instead! Called from #{caller.first}" unless hash.empty?
-				super(flags: PG::Coder::TIMESTAMP_DB_LOCAL | PG::Coder::TIMESTAMP_APP_LOCAL, **hash, **kwargs)
+				super(**hash, **kwargs, flags: PG::Coder::TIMESTAMP_DB_LOCAL | PG::Coder::TIMESTAMP_APP_LOCAL)
 			end
 		end
 

--- a/spec/pg/type_spec.rb
+++ b/spec/pg/type_spec.rb
@@ -523,11 +523,14 @@ describe "PG::Type derivations" do
 			end
 		end
 
-		it "should overwrite default values as hash" do
+		it "should overwrite default format" do
 			t = nil
 			expect_deprecated_coder_init do
 				t = PG::BinaryEncoder::Int4.new({format: 0})
 			end
+			expect( t.format ).to eq( 0 )
+
+			t = PG::BinaryEncoder::Int4.new(format: 0)
 			expect( t.format ).to eq( 0 )
 		end
 
@@ -557,6 +560,27 @@ describe "PG::Type derivations" do
 			expect( t.name ).to eq( "abcä" )
 			expect_deprecated_coder_init { t = PG::TextDecoder::TimestampWithTimeZone.new({name: "abcä"}) }
 			expect( t.name ).to eq( "abcä" )
+		end
+
+		it "shouldn't overwrite timestamp flags" do
+			t = PG::TextDecoder::TimestampUtc.new({flags: PG::Coder::TIMESTAMP_DB_LOCAL})
+			expect( t.flags ).to eq( PG::Coder::TIMESTAMP_DB_UTC | PG::Coder::TIMESTAMP_APP_UTC )
+			t = PG::TextDecoder::TimestampUtcToLocal.new({flags: PG::Coder::TIMESTAMP_APP_UTC})
+			expect( t.flags ).to eq( PG::Coder::TIMESTAMP_DB_UTC | PG::Coder::TIMESTAMP_APP_LOCAL )
+			t = PG::TextDecoder::TimestampLocal.new({flags: PG::Coder::TIMESTAMP_DB_UTC})
+			expect( t.flags ).to eq( PG::Coder::TIMESTAMP_DB_LOCAL | PG::Coder::TIMESTAMP_APP_LOCAL )
+
+			t = PG::BinaryDecoder::TimestampUtc.new({flags: PG::Coder::TIMESTAMP_DB_LOCAL})
+			expect( t.flags ).to eq( PG::Coder::TIMESTAMP_DB_UTC | PG::Coder::TIMESTAMP_APP_UTC )
+			t = PG::BinaryDecoder::TimestampUtcToLocal.new({flags: PG::Coder::TIMESTAMP_APP_UTC})
+			expect( t.flags ).to eq( PG::Coder::TIMESTAMP_DB_UTC | PG::Coder::TIMESTAMP_APP_LOCAL )
+			t = PG::BinaryDecoder::TimestampLocal.new({flags: PG::Coder::TIMESTAMP_DB_UTC})
+			expect( t.flags ).to eq( PG::Coder::TIMESTAMP_DB_LOCAL | PG::Coder::TIMESTAMP_APP_LOCAL )
+
+			t = PG::BinaryEncoder::TimestampUtc.new({flags: PG::Coder::TIMESTAMP_DB_LOCAL})
+			expect( t.flags ).to eq( PG::Coder::TIMESTAMP_DB_UTC )
+			t = PG::BinaryEncoder::TimestampLocal.new({flags: PG::Coder::TIMESTAMP_APP_LOCAL})
+			expect( t.flags ).to eq( PG::Coder::TIMESTAMP_DB_LOCAL )
 		end
 
 		it "should deny changes when frozen" do


### PR DESCRIPTION
It is unexpected, since it makes the coder behave contrary to the class name. Moreover it causes a regression in rails:
  https://github.com/rails/rails/issues/48049

Fixes #524