### PR TITLE
Add category to deprecation warnings

### DIFF
--- a/lib/pg/binary_decoder/timestamp.rb
+++ b/lib/pg/binary_decoder/timestamp.rb
@@ -6,19 +6,19 @@ module PG
 		# Convenience classes for timezone options
 		class TimestampUtc < Timestamp
 			def initialize(hash={}, **kwargs)
-				warn "PG::Coder.new(hash) is deprecated. Please use keyword arguments instead! Called from #{caller.first}" unless hash.empty?
+				warn("PG::Coder.new(hash) is deprecated. Please use keyword arguments instead! Called from #{caller.first}", category: :deprecated) unless hash.empty?
 				super(**hash, **kwargs, flags: PG::Coder::TIMESTAMP_DB_UTC | PG::Coder::TIMESTAMP_APP_UTC)
 			end
 		end
 		class TimestampUtcToLocal < Timestamp
 			def initialize(hash={}, **kwargs)
-				warn "PG::Coder.new(hash) is deprecated. Please use keyword arguments instead! Called from #{caller.first}" unless hash.empty?
+				warn("PG::Coder.new(hash) is deprecated. Please use keyword arguments instead! Called from #{caller.first}", category: :deprecated) unless hash.empty?
 				super(**hash, **kwargs, flags: PG::Coder::TIMESTAMP_DB_UTC | PG::Coder::TIMESTAMP_APP_LOCAL)
 			end
 		end
 		class TimestampLocal < Timestamp
 			def initialize(hash={}, **kwargs)
-				warn "PG::Coder.new(hash) is deprecated. Please use keyword arguments instead! Called from #{caller.first}" unless hash.empty?
+				warn("PG::Coder.new(hash) is deprecated. Please use keyword arguments instead! Called from #{caller.first}", category: :deprecated) unless hash.empty?
 				super(**hash, **kwargs, flags: PG::Coder::TIMESTAMP_DB_LOCAL | PG::Coder::TIMESTAMP_APP_LOCAL)
 			end
 		end

--- a/lib/pg/binary_encoder/timestamp.rb
+++ b/lib/pg/binary_encoder/timestamp.rb
@@ -6,13 +6,13 @@ module PG
 		# Convenience classes for timezone options
 		class TimestampUtc < Timestamp
 			def initialize(hash={}, **kwargs)
-				warn "PG::Coder.new(hash) is deprecated. Please use keyword arguments instead! Called from #{caller.first}" unless hash.empty?
+				warn("PG::Coder.new(hash) is deprecated. Please use keyword arguments instead! Called from #{caller.first}", category: :deprecated) unless hash.empty?
 				super(**hash, **kwargs, flags: PG::Coder::TIMESTAMP_DB_UTC)
 			end
 		end
 		class TimestampLocal < Timestamp
 			def initialize(hash={}, **kwargs)
-				warn "PG::Coder.new(hash) is deprecated. Please use keyword arguments instead! Called from #{caller.first}" unless hash.empty?
+				warn("PG::Coder.new(hash) is deprecated. Please use keyword arguments instead! Called from #{caller.first}", category: :deprecated) unless hash.empty?
 				super(**hash, **kwargs, flags: PG::Coder::TIMESTAMP_DB_LOCAL)
 			end
 		end

--- a/lib/pg/coder.rb
+++ b/lib/pg/coder.rb
@@ -7,7 +7,7 @@ module PG
 
 		module BinaryFormatting
 			def initialize(hash={}, **kwargs)
-				warn "PG::Coder.new(hash) is deprecated. Please use keyword arguments instead! Called from #{caller.first}" unless hash.empty?
+				warn("PG::Coder.new(hash) is deprecated. Please use keyword arguments instead! Called from #{caller.first}", category: :deprecated) unless hash.empty?
 				super(format: 1, **hash, **kwargs)
 			end
 		end
@@ -15,7 +15,7 @@ module PG
 
 		# Create a new coder object based on the attribute Hash.
 		def initialize(hash=nil, **kwargs)
-			warn "PG::Coder.new(hash) is deprecated. Please use keyword arguments instead! Called from #{caller.first}" if hash
+			warn("PG::Coder.new(hash) is deprecated. Please use keyword arguments instead! Called from #{caller.first}", category: :deprecated) if hash
 
 			(hash || kwargs).each do |key, val|
 				send("#{key}=", val)

--- a/lib/pg/text_decoder/timestamp.rb
+++ b/lib/pg/text_decoder/timestamp.rb
@@ -6,19 +6,19 @@ module PG
 		# Convenience classes for timezone options
 		class TimestampUtc < Timestamp
 			def initialize(hash={}, **kwargs)
-				warn "PG::Coder.new(hash) is deprecated. Please use keyword arguments instead! Called from #{caller.first}" unless hash.empty?
+				warn("PG::Coder.new(hash) is deprecated. Please use keyword arguments instead! Called from #{caller.first}", category: :deprecated) unless hash.empty?
 				super(**hash, **kwargs, flags: PG::Coder::TIMESTAMP_DB_UTC | PG::Coder::TIMESTAMP_APP_UTC)
 			end
 		end
 		class TimestampUtcToLocal < Timestamp
 			def initialize(hash={}, **kwargs)
-				warn "PG::Coder.new(hash) is deprecated. Please use keyword arguments instead! Called from #{caller.first}" unless hash.empty?
+				warn("PG::Coder.new(hash) is deprecated. Please use keyword arguments instead! Called from #{caller.first}", category: :deprecated) unless hash.empty?
 				super(**hash, **kwargs, flags: PG::Coder::TIMESTAMP_DB_UTC | PG::Coder::TIMESTAMP_APP_LOCAL)
 			end
 		end
 		class TimestampLocal < Timestamp
 			def initialize(hash={}, **kwargs)
-				warn "PG::Coder.new(hash) is deprecated. Please use keyword arguments instead! Called from #{caller.first}" unless hash.empty?
+				warn("PG::Coder.new(hash) is deprecated. Please use keyword arguments instead! Called from #{caller.first}", category: :deprecated) unless hash.empty?
 				super(**hash, **kwargs, flags: PG::Coder::TIMESTAMP_DB_LOCAL | PG::Coder::TIMESTAMP_APP_LOCAL)
 			end
 		end

--- a/spec/pg/type_spec.rb
+++ b/spec/pg/type_spec.rb
@@ -515,9 +515,16 @@ describe "PG::Type derivations" do
 
 		def expect_deprecated_coder_init
 			if RUBY_VERSION >= '3'
-				expect do
-					yield
-				end.to output(/deprecated.*type_spec.rb/).to_stderr
+				begin
+					prev_deprecated = Warning[:deprecated]
+					Warning[:deprecated] = true
+
+					expect do
+						yield
+					end.to output(/deprecated.*type_spec.rb/).to_stderr
+				ensure
+					Warning[:deprecated] = prev_deprecated
+				end
 			else
 				yield
 			end


### PR DESCRIPTION
See https://github.com/ged/ruby-pg/issues/523
See https://ruby-doc.org/3.2.2/Warning.html
See https://bugs.ruby-lang.org/issues/17000

The deprecation warning about `PG::Coder.new(hash)` introduced in v1.5.0 is so frequently reported that it would be more useful if a user had better control over the warning.

This PR sets the category for deprecation warnings. Setting `category: :deprecated` will only show warnings to users who either set `Warning[:deprecated] = true` or set `RUBYOPT=-W:deprecated`. `Warning[:deprecated] = false` by default since Ruby 2.7.2, so it suppresses the warning for most users.