### PR TITLE
Fix possible segfault when creating new PG::Result

### DIFF
--- a/ext/pg_result.c
+++ b/ext/pg_result.c
@@ -1424,8 +1424,9 @@ pgresult_type_map_set(VALUE self, VALUE typemap)
 	/* Check type of method param */
 	TypedData_Get_Struct(typemap, t_typemap, &pg_typemap_type, p_typemap);
 
-	RB_OBJ_WRITE(self, &this->typemap, p_typemap->funcs.fit_to_result( typemap, self ));
-	this->p_typemap = RTYPEDDATA_DATA( this->typemap );
+	typemap = p_typemap->funcs.fit_to_result( typemap, self );
+	RB_OBJ_WRITE(self, &this->typemap, typemap);
+	this->p_typemap = RTYPEDDATA_DATA( typemap );
 
 	return typemap;
 }

--- a/ext/pg_type_map_by_column.c
+++ b/ext/pg_type_map_by_column.c
@@ -287,9 +287,7 @@ pg_tmbc_init(VALUE self, VALUE conv_ary)
 			t_pg_coder *p_coder;
 			/* Check argument type and store the coder pointer */
 			TypedData_Get_Struct(obj, t_pg_coder, &pg_coder_type, p_coder);
-			if( p_coder ){
-				RB_OBJ_WRITTEN(self, Qnil, p_coder->coder_obj);
-			}
+			RB_OBJ_WRITTEN(self, Qnil, p_coder->coder_obj);
 			this->convs[i].cconv = p_coder;
 		}
 	}


### PR DESCRIPTION
Initialize connection and typemap prior to any object allocations, to make sure valid objects are marked.

This regression was introduced in commit 5061020c28d694464a5fa5474062d8486912daa1 while introducing write barriers. However it is not necessary to use `RB_OBJ_WRITE` when the "old" object (1st argument) is not yet created or immediately after it was created. The initial assignment can and must be done before processing the typemap as it was before the above commit.

Fixes #530