### PR TITLE
Fix MSVC 2022 Compilation

### DIFF
--- a/ext/extconf.rb
+++ b/ext/extconf.rb
@@ -60,6 +60,10 @@ else
 	if dlldir && RbConfig::CONFIG["RPATHFLAG"].to_s.empty?
 		append_ldflags "-Wl,-rpath,#{dlldir.quote}"
 	end
+
+	if /mswin/ =~ RUBY_PLATFORM
+		$libs = append_library($libs, 'ws2_32')
+	end
 end
 
 $stderr.puts "Using libpq from #{dlldir}"


### PR DESCRIPTION
This PR fixes compiling the pg extension with MSVC 2022 when using extconf.rb, nmake and libpq installed by vcpkg (not mingw64).

Running the command:

ruby extconf.rb --without-pg-config --with-pg-include=c:\Source\vcpkg\installed\x64-windows\include --with-pg-lib=c:\Source\vcpkg\installed\x64-windows\lib

Fails with linker errors:

pg_connection.obj : error LNK2019: unresolved external symbol __imp_WSAGetLastError referenced in function pg_rb_thread_io_wait

This is fixed by adding ws2_32.lib to the linker command.

Not sure I am adding the extra library in the best place (or the correct way), but this does fix the issue for me.