### PR TITLE
Call pgconn_set_internal_encoding_index in all branches of pgconn_set_default_encoding

### DIFF
--- a/ext/pg_connection.c
+++ b/ext/pg_connection.c
@@ -4180,6 +4180,7 @@ pgconn_set_default_encoding( VALUE self )
 		if ( pgconn_set_client_encoding_async(self, rb_str_new_cstr(encname)) != 0 )
 			rb_warning( "Failed to set the default_internal encoding to %s: '%s'",
 			         encname, PQerrorMessage(conn) );
+		pgconn_set_internal_encoding_index( self );
 		return rb_enc_from_encoding( enc );
 	} else {
 		pgconn_set_internal_encoding_index( self );


### PR DESCRIPTION
This PR reintroduces a call to `pgconn_set_internal_encoding_index` in `pgconn_set_default_encoding`. This call was removed in version `1.3.0` (specifically in this [PR](https://github.com/ged/ruby-pg/pull/397)).

When `Encoding.default_internal` is set, ruby-pg sends a `SET client_encoding TO ...` query, if that query succeeds everything works great. If it fails and the connection is closed, well nothing breaks. 

Now assuming Ruby and Postgres are both using UTF-8 encoding, if that query fails AND the connection remains open, we end up with desynchronized encoding between Ruby and Ruby-pg where Ruby's encoding is UTF-8, Postgres Encoding is UTF-8 but Ruby-pg falls back to `SQL_ASCII` (I think?) causing it to encode the incoming UTF-8 strings from Postgres into ASCII.

Version `1.2.3` handles encoding query failure gracefully. The following output shows this behavior in action in versions `1.2.3`, `1.5.3`, and a patched version of `1.5.3`  
```
[1.2.3 Response] [{"user_id"=>"1", "username"=>"™™™™™™"}, {"user_id"=>"2", "username"=>"™™™™™™"}]
[1.5.3 Response] [{"user_id"=>"1", "username"=>"\xE2\x84\xA2\xE2\x84\xA2\xE2\x84\xA2\xE2\x84\xA2\xE2\x84\xA2\xE2\x84\xA2"}, {"user_id"=>"2", "username"=>"\xE2\x84\xA2\xE2\x84\xA2\xE2\x84\xA2\xE2\x84\xA2\xE2\x84\xA2\xE2\x84\xA2"}]
[1.5.3-fix Response] [{"user_id"=>"1", "username"=>"™™™™™™"}, {"user_id"=>"2", "username"=>"™™™™™™"}]
```

This [repo](https://github.com/drdrsh/ruby-pg-report0) has a docker stack that reproduces that behavior and demonestrates the fix.