### PR TITLE
Avoid sending client encoding query at startup if not necessary

### DIFF
--- a/ext/pg_connection.c
+++ b/ext/pg_connection.c
@@ -4176,8 +4176,11 @@ pgconn_set_default_encoding( VALUE self )
 
 	rb_check_frozen(self);
 	if (( enc = rb_default_internal_encoding() )) {
+		rb_encoding * conn_encoding = pg_conn_enc_get( conn );
 		encname = pg_get_rb_encoding_as_pg_encoding( enc );
-		if ( pgconn_set_client_encoding_async(self, rb_str_new_cstr(encname)) != 0 )
+		bool ruby_and_conn_encoding_equal = conn_encoding && strcmp(enc->name, conn_encoding->name) == 0;
+
+		if ( !ruby_and_conn_encoding_equal && pgconn_set_client_encoding_async(self, rb_str_new_cstr(encname)) != 0 )
 			rb_warning( "Failed to set the default_internal encoding to %s: '%s'",
 			         encname, PQerrorMessage(conn) );
 		return rb_enc_from_encoding( enc );


### PR DESCRIPTION
We are using a Postgres proxy with ruby-pg that routes queries based on the presence of a comment, we want to add that routing comment to all queries, we are using Rails so we have control over the queries sent by ActiveRecord but we cannot control queries triggered by `ruby-pg`. The query in question is the query triggered by `pgconn_set_default_encoding`. 

Now, there are a couple of ways to get rid of this startup query
1. Leaving `Encoding.default_internal` set to `nil` but that is something we cannot really do because it is set by Rails and it does not seem safe to unset a value set by Rails core.
2. Disable `set_default_encoding` by monkeypatching the method in Ruby land. This can only be done in versions after the introduction of the async connect apis. However, doing this will bypass a call to the all-so-important method `pgconn_set_internal_encoding_index` which is not exposed to Ruby land code so we cannot call it

I think this query can be eliminated by checking the client encoding on the connection and comparing that against the Ruby encoding. Checking the client encoding on the connection is an offline operation.

I was able to test this with connections that had client encoding set in the url or those that are not but I am not sure where I should add tests for this in this repo

