### PR TITLE
Don't ship POT files in gem.

### DIFF
--- a/pg.gemspec
+++ b/pg.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
   # Specify which files should be added to the gem when it is released.
   # The `git ls-files -z` loads the files in the RubyGem that have been added into git.
   spec.files = Dir.chdir(File.expand_path(__dir__)) do
-    `git ls-files -z`.split("\x0").reject { |f| f.match(%r{\A(?:test|spec|features)/}) }
+    `git ls-files -z`.split("\x0").reject { |f| f.match(%r{\A(?:test|spec|features|translation)/}) }
   end
   spec.extensions    = ["ext/extconf.rb"]
   spec.require_paths = ["lib"]


### PR DESCRIPTION
README.md is already translated when it reaches the gem form, no need to ship the files for translation.