### PR TITLE
Renew address resolution in conn.reset

### DIFF
--- a/spec/helpers.rb
+++ b/spec/helpers.rb
@@ -675,6 +675,11 @@ EOT
 			ENV.update(old_values)
 		end
 	end
+
+	# Append or change 'rubypg_test' host entry in /etc/hosts to a given IP address
+	def set_etc_hosts(hostaddr)
+		system "sudo --non-interactive sed -i '/.* rubypg_test$/{h;s/.*/#{hostaddr} rubypg_test/};${x;/^$/{s//#{hostaddr} rubypg_test/;H};x}' /etc/hosts" or skip("unable to change /etc/hosts file")
+	end
 end
 
 

--- a/spec/pg/connection_spec.rb
+++ b/spec/pg/connection_spec.rb
@@ -1690,6 +1690,23 @@ describe PG::Connection do
 		conn.close
 	end
 
+	it "refreshs DNS address while conn.reset", :without_transaction, :ipv6 do
+		set_etc_hosts "::1"
+		conn = described_class.connect( "postgres://rubypg_test/test" )
+		conn.exec("select 1")
+
+		set_etc_hosts "127.0.0.1"
+		conn.reset
+		conn.exec("select 1")
+
+		set_etc_hosts "::2"
+		expect do
+			conn.reset
+			conn.exec("select 1")
+		end.to raise_error(PG::Error)
+	end
+
+
 	it "closes the IO fetched from #socket_io when the connection is closed", :without_transaction do
 		conn = PG.connect( @conninfo )
 		io = conn.socket_io


### PR DESCRIPTION
libpq resolves the host address while PQreset, but ruby-pg doesn't. This is because we explicit set the `hostaddr` connection parameter when the connection is established the first time. This prevents a newly DNS resolution when running PQresetStart.

This patch adds DNS resolution to `conn.reset`
Since we can not change the connection parameters after connection start, the underlying PGconn pointer is exchanged in reset_start2. This is done by a PQfinish() + PQconnectStart() sequence. That way the `hostaddr` parameter is updated and a new connection is established with it.

There is a `/etc/hosts` and `sudo` based test in the specs.
The behavior of libpq is slightly different to that of ruby-pg.
It can be verified by the following code:

```ruby
require "pg"

puts "pg version: #{PG::VERSION}"
# PG::Connection.async_api = false  # Enable to see libpq behaviour

system "sudo sed -i 's/.* abcd/::1 abcd/g' /etc/hosts"
conn = PG.connect host: "abcd", password: "l"
conn.exec("select 1")
p conn.conninfo_hash.slice(:host, :hostaddr, :port)

system "sudo sed -i 's/.* abcd/127.0.0.1 abcd/g' /etc/hosts"
conn.reset
conn.exec("select 1")
p conn.conninfo_hash.slice(:host, :hostaddr, :port)

system "sudo sed -i 's/.* abcd/::2 abcd/g' /etc/hosts"
conn.reset
conn.exec("select 1")
p conn.conninfo_hash.slice(:host, :hostaddr, :port)
```

This gives the following output showing, that the IP address is updated:
```
pg version: 1.5.5
{:host=>"abcd", :hostaddr=>"::1", :port=>"5432"}
{:host=>"abcd", :hostaddr=>"127.0.0.1", :port=>"5432"}
ruby-pg/lib/pg/connection.rb:573:in `reset_start2': connection to server at "::2", port 5432 failed: Network is unreachable (PG::ConnectionBad)
	Is the server running on that host and accepting TCP/IP connections?
```

Whereas libpq resolves similarly with `async_api=false`, but doesn't raise the error in `conn.reset` but in the subsequent `conn.exec`.

```
pg version: 1.5.5
{:host=>"abcd", :hostaddr=>nil, :port=>"5432"}
{:host=>"abcd", :hostaddr=>nil, :port=>"5432"}
test-reset-dns.rb:18:in `sync_exec': no connection to the server (PG::UnableToSend)
```

Fixes #558