### PR TITLE
Add PG::RollbackTransaction as an option to exit conn.transaction

### DIFF
--- a/lib/pg/connection.rb
+++ b/lib/pg/connection.rb
@@ -306,6 +306,11 @@ class PG::Connection
 		rollback = false
 		exec "BEGIN"
 		yield(self)
+	rescue PG::RollbackTransaction
+		rollback = true
+		cancel if transaction_status == PG::PQTRANS_ACTIVE
+		block
+		exec "ROLLBACK"
 	rescue Exception
 		rollback = true
 		cancel if transaction_status == PG::PQTRANS_ACTIVE

--- a/lib/pg/exceptions.rb
+++ b/lib/pg/exceptions.rb
@@ -21,5 +21,11 @@ module PG
 	class NotInBlockingMode < PG::Error
 	end
 
+	# PG::Connection#transaction uses this exception to distinguish a deliberate rollback from other exceptional situations.
+	# Normally, raising an exception will cause the .transaction method to rollback the database transaction and pass on the exception.
+	# But if you raise an PG::RollbackTransaction exception, then the database transaction will be rolled back, without passing on the exception.
+	class RollbackTransaction < StandardError
+	end
+
 end # module PG
 

--- a/spec/pg/connection_spec.rb
+++ b/spec/pg/connection_spec.rb
@@ -920,6 +920,24 @@ describe PG::Connection do
 			end
 		end
 
+		it "rolls back a transaction if a PG::RollbackTransaction exception is raised" do
+			# abort the per-example transaction so we can test our own
+			@conn.exec( 'ROLLBACK' )
+			@conn.exec( "CREATE TABLE pie ( flavor TEXT )" )
+
+			begin
+				@conn.transaction do
+					@conn.exec( "INSERT INTO pie VALUES ('rhubarb'), ('cherry'), ('schizophrenia')" )
+					raise PG::RollbackTransaction
+				end
+
+				res = @conn.exec( "SELECT * FROM pie" )
+				expect( res.ntuples ).to eq( 0 )
+			ensure
+				@conn.exec( "DROP TABLE pie" )
+			end
+		end
+
 		it "commits even if the block includes an early break/return" do
 			# abort the per-example transaction so we can test our own
 			@conn.exec( 'ROLLBACK' )


### PR DESCRIPTION
Like in rails: https://api.rubyonrails.org/classes/ActiveRecord/Rollback.html