### PR TITLE
Make `pgconn_connect_poll` close the socket prior to calling `PQconnectPoll`

### DIFF
--- a/ext/pg_connection.c
+++ b/ext/pg_connection.c
@@ -515,9 +515,9 @@ static VALUE
 pgconn_connect_poll(VALUE self)
 {
 	PostgresPollingStatusType status;
-	status = gvl_PQconnectPoll(pg_get_pgconn(self));
 
 	pgconn_close_socket_io(self);
+	status = gvl_PQconnectPoll(pg_get_pgconn(self));
 
 	return INT2FIX((int)status);
 }
@@ -615,9 +615,9 @@ static VALUE
 pgconn_reset_poll(VALUE self)
 {
 	PostgresPollingStatusType status;
-	status = gvl_PQresetPoll(pg_get_pgconn(self));
 
 	pgconn_close_socket_io(self);
+	status = gvl_PQresetPoll(pg_get_pgconn(self));
 
 	return INT2FIX((int)status);
 }

--- a/spec/pg/connection_spec.rb
+++ b/spec/pg/connection_spec.rb
@@ -577,6 +577,21 @@ describe PG::Connection do
 			conn.close
 		end
 
+		it "doesn't notify the wrong thread about closed socket (Bug #564)" do
+			10.times do
+				10.times.map do
+					Thread.new do
+						Thread.current.report_on_exception = false
+						expect do
+							threaded_conn = PG.connect( @conninfo + " sslcert=tmp_test_specs/data/ruby-pg-ca-cert" )
+							res = threaded_conn.exec("SELECT 1")
+							threaded_conn.close
+						end.not_to raise_error
+					end
+				end.each(&:join)
+			end
+		end
+
 		it "can use conn.reset_start to restart the connection" do
 			ios = IO.pipe
 			conn = described_class.connect_start( @conninfo )


### PR DESCRIPTION
Make `pgconn_connect_poll` close the socket prior to calling `PQconnectPoll`

Since `PQconnectPoll` can change the underlying socket and thus the file descriptor, closing the socket after can manifest a race condition where libpq has closed the socket and another thread has opened a socket with the recycled file descriptor. When the original socket is closed from Ruby, the VM will notify the new thread that the FD has closed (erroneously) resulting in an exception.

This is an exception I encountered in a production environment (C Ruby 3.3), somewhat sporadically  It is quite misleading as the way this manifests is that the exception raises [while waiting](https://github.com/ged/ruby-pg/blob/master/lib/pg/connection.rb#L674) on the socket, so it seems as if connections are getting shared between threads.  

The reason this happens is because when the IO object is closed on the Ruby side, the VM [calls rb_notify_fd_close](https://github.com/ruby/ruby/blob/8191735b73eac4486eebac6530bd92080ee23b9a/io.c#L5661) which in turn sends an exception to any [threads waiting on the file descriptor](https://github.com/ruby/ruby/blob/8191735b73eac4486eebac6530bd92080ee23b9a/thread.c#L2631). On the Ruby 2.x path does not have this problem as `IO.select` will return the exception array, although I believe the VM still calls `close()` 

