### PR TITLE
Fix typos

### DIFF
--- a/History.md
+++ b/History.md
@@ -92,7 +92,7 @@ Removed:
 Repository:
 
 - `rake test` tries to find PostgreSQL server commands by pg_config [#503](https://github.com/ged/ruby-pg/pull/503)
-  So there's no need to set the PATH manuelly any longer.
+  So there's no need to set the PATH manually any longer.
 
 
 ## v1.4.6 [2023-02-26] Lars Kanis <lars@greiz-reinsdorf.de>
@@ -161,7 +161,7 @@ Added:
 Bugfixes:
 
 - Try IPv6 and IPv4 addresses, if DNS resolves to both. [#452](https://github.com/ged/ruby-pg/pull/452)
-- Re-add block-call semantics to PG::Connection.new accidently removed in pg-1.3.0. [#454](https://github.com/ged/ruby-pg/pull/454)
+- Re-add block-call semantics to PG::Connection.new accidentally removed in pg-1.3.0. [#454](https://github.com/ged/ruby-pg/pull/454)
 - Handle client error after all data consumed in #copy_data for output. [#455](https://github.com/ged/ruby-pg/pull/455)
 - Avoid spurious keyword argument warning on Ruby 2.7. [#456](https://github.com/ged/ruby-pg/pull/456)
 - Change connection setup to respect connect_timeout parameter. [#459](https://github.com/ged/ruby-pg/pull/459)
@@ -200,7 +200,7 @@ Bugfixes:
 
 - Don't leak IO in case of connection errors. [#439](https://github.com/ged/ruby-pg/pull/439)
   Previously it was kept open until the PG::Connection was garbage collected.
-- Fix a performance regession in conn.get_result noticed in single row mode. [#442](https://github.com/ged/ruby-pg/pull/442)
+- Fix a performance regression in conn.get_result noticed in single row mode. [#442](https://github.com/ged/ruby-pg/pull/442)
 - Fix occasional error Errno::EBADF (Bad file descriptor) while connecting. [#444](https://github.com/ged/ruby-pg/pull/444)
 - Fix compatibility of res.stream_each* methods with Fiber.scheduler. [#446](https://github.com/ged/ruby-pg/pull/446)
 - Remove FL_TEST and FL_SET, which are MRI-internal. [#437](https://github.com/ged/ruby-pg/pull/437)
@@ -286,7 +286,7 @@ Type cast enhancements:
 - Add PG::BasicTypeMapForQueries::BinaryData for encoding of bytea columns. [#348](https://github.com/ged/ruby-pg/pull/348)
 - Reduce time to build coder maps and permit to reuse them for several type maps per PG::BasicTypeRegistry::CoderMapsBundle.new(conn) . [#376](https://github.com/ged/ruby-pg/pull/376)
 - Make BasicTypeRegistry a class and use a global default instance of it.
-  Now a local type registry can be instanciated and given to the type map, to avoid changing shared global states.
+  Now a local type registry can be instantiated and given to the type map, to avoid changing shared global states.
 - Allow PG::BasicTypeMapForQueries to take a Proc as callback for undefined types.
 
 Other Enhancements:

--- a/ext/pg.c
+++ b/ext/pg.c
@@ -543,7 +543,7 @@ Init_pg_ext(void)
 	/* Result#result_error_field argument constant
 	 *
 	 * The SQLSTATE code for the error.
-	 * The SQLSTATE code identies the type of error that has occurred; it can be used by front-end applications to perform specific operations (such as error handling) in response to a particular database error.
+	 * The SQLSTATE code identities the type of error that has occurred; it can be used by front-end applications to perform specific operations (such as error handling) in response to a particular database error.
 	 * For a list of the possible SQLSTATE codes, see Appendix A.
 	 * This field is not localizable, and is always present.
 	 */

--- a/ext/pg_connection.c
+++ b/ext/pg_connection.c
@@ -2363,7 +2363,7 @@ static VALUE
 pg_rb_io_wait(VALUE io, VALUE events, VALUE timeout) {
 #if defined(HAVE_RUBY_FIBER_SCHEDULER_H)
 	/* We don't support Fiber.scheduler on Windows ruby-3.0 because there is no fast way to check whether a scheduler is active.
-	 * Fortunatelly ruby-3.1 offers a C-API for it.
+	 * Fortunately ruby-3.1 offers a C-API for it.
 	 */
 	VALUE scheduler = rb_fiber_scheduler_current();
 
@@ -3169,7 +3169,7 @@ pgconn_async_get_last_result(VALUE self)
  * Returns:
  * * +nil+  when the connection is already idle
  * * +true+  when some results have been discarded
- * * +false+  when a failure occured and the connection was closed
+ * * +false+  when a failure occurred and the connection was closed
  *
  */
 static VALUE

--- a/ext/pg_copy_coder.c
+++ b/ext/pg_copy_coder.c
@@ -235,7 +235,7 @@ pg_text_enc_copy_row(t_pg_coder *conv, VALUE value, char *out, VALUE *intermedia
 		char *ptr1;
 		char *ptr2;
 		int strlen;
-		int backslashs;
+		int backslashes;
 		VALUE subint;
 		VALUE entry;
 
@@ -286,19 +286,19 @@ pg_text_enc_copy_row(t_pg_coder *conv, VALUE value, char *out, VALUE *intermedia
 					ptr2 = current_out + strlen;
 
 					/* count required backlashs */
-					for(backslashs = 0; ptr1 != ptr2; ptr1++) {
+					for(backslashes = 0; ptr1 != ptr2; ptr1++) {
 						/* Escape backslash itself, newline, carriage return, and the current delimiter character. */
 						if(*ptr1 == '\\' || *ptr1 == '\n' || *ptr1 == '\r' || *ptr1 == this->delimiter){
-							backslashs++;
+							backslashes++;
 						}
 					}
 
 					ptr1 = current_out + strlen;
-					ptr2 = current_out + strlen + backslashs;
+					ptr2 = current_out + strlen + backslashes;
 					current_out = ptr2;
 
 					/* Then store the escaped string on the final position, walking
-					 * right to left, until all backslashs are placed. */
+					 * right to left, until all backslashes are placed. */
 					while( ptr1 != ptr2 ) {
 						*--ptr2 = *--ptr1;
 						if(*ptr1 == '\\' || *ptr1 == '\n' || *ptr1 == '\r' || *ptr1 == this->delimiter){
@@ -391,7 +391,7 @@ pg_bin_enc_copy_row(t_pg_coder *conv, VALUE value, char *out, VALUE *intermediat
 
 		switch(TYPE(entry)){
 			case T_NIL:
-				/* 4 bytes for -1 indicationg a NULL value */
+				/* 4 bytes for -1 indicating a NULL value */
 				PG_RB_STR_ENSURE_CAPA( *intermediate, 4, current_out, end_capa_ptr );
 				write_nbo32(-1, current_out);
 				current_out += 4;

--- a/ext/pg_record_coder.c
+++ b/ext/pg_record_coder.c
@@ -198,7 +198,7 @@ pg_text_enc_record(t_pg_coder *conv, VALUE value, char *out, VALUE *intermediate
 		char *ptr1;
 		char *ptr2;
 		long strlen;
-		int backslashs;
+		int backslashes;
 		VALUE subint;
 		VALUE entry;
 
@@ -249,19 +249,19 @@ pg_text_enc_record(t_pg_coder *conv, VALUE value, char *out, VALUE *intermediate
 					ptr2 = current_out + strlen;
 
 					/* count required backlashs */
-					for(backslashs = 0; ptr1 != ptr2; ptr1++) {
+					for(backslashes = 0; ptr1 != ptr2; ptr1++) {
 						/* Escape backslash itself, newline, carriage return, and the current delimiter character. */
 						if(*ptr1 == '"' || *ptr1 == '\\'){
-							backslashs++;
+							backslashes++;
 						}
 					}
 
 					ptr1 = current_out + strlen;
-					ptr2 = current_out + strlen + backslashs;
+					ptr2 = current_out + strlen + backslashes;
 					current_out = ptr2;
 
 					/* Then store the escaped string on the final position, walking
-					 * right to left, until all backslashs are placed. */
+					 * right to left, until all backslashes are placed. */
 					while( ptr1 != ptr2 ) {
 						*--ptr2 = *--ptr1;
 						if(*ptr1 == '"' || *ptr1 == '\\'){

--- a/ext/pg_result.c
+++ b/ext/pg_result.c
@@ -664,7 +664,7 @@ pgresult_verbose_error_message(VALUE self, VALUE verbosity, VALUE show_context)
  * An example:
  *
  *   begin
- *       conn.exec( "SELECT * FROM nonexistant_table" )
+ *       conn.exec( "SELECT * FROM nonexistent_table" )
  *   rescue PG::Error => err
  *       p [
  *           err.result.error_field( PG::Result::PG_DIAG_SEVERITY ),
@@ -684,7 +684,7 @@ pgresult_verbose_error_message(VALUE self, VALUE verbosity, VALUE show_context)
  *
  * Outputs:
  *
- *   ["ERROR", "42P01", "relation \"nonexistant_table\" does not exist", nil, nil,
+ *   ["ERROR", "42P01", "relation \"nonexistent_table\" does not exist", nil, nil,
  *    "15", nil, nil, nil, "path/to/parse_relation.c", "857", "parserOpenTable"]
  */
 static VALUE

--- a/ext/pg_text_encoder.c
+++ b/ext/pg_text_encoder.c
@@ -437,7 +437,7 @@ quote_array_buffer( void *_this, char *p_in, int strlen, char *p_out ){
 	t_pg_composite_coder *this = _this;
 	char *ptr1;
 	char *ptr2;
-	int backslashs = 0;
+	int backslashes = 0;
 	int needquote;
 
 	/* count data plus backslashes; detect chars needing quotes */
@@ -454,7 +454,7 @@ quote_array_buffer( void *_this, char *p_in, int strlen, char *p_out ){
 
 		if (ch == '"' || ch == '\\'){
 			needquote = 1;
-			backslashs++;
+			backslashes++;
 		} else if (ch == '{' || ch == '}' || ch == this->delimiter ||
 					ch == ' ' || ch == '\t' || ch == '\n' || ch == '\r' || ch == '\v' || ch == '\f'){
 			needquote = 1;
@@ -463,12 +463,12 @@ quote_array_buffer( void *_this, char *p_in, int strlen, char *p_out ){
 
 	if( needquote ){
 		ptr1 = p_in + strlen;
-		ptr2 = p_out + strlen + backslashs + 2;
+		ptr2 = p_out + strlen + backslashes + 2;
 		/* Write end quote */
 		*--ptr2 = '"';
 
 		/* Then store the escaped string on the final position, walking
-			* right to left, until all backslashs are placed. */
+			* right to left, until all backslashes are placed. */
 		while( ptr1 != p_in ) {
 			*--ptr2 = *--ptr1;
 			if(*ptr2 == '"' || *ptr2 == '\\'){
@@ -477,7 +477,7 @@ quote_array_buffer( void *_this, char *p_in, int strlen, char *p_out ){
 		}
 		/* Write start quote */
 		*p_out = '"';
-		return strlen + backslashs + 2;
+		return strlen + backslashes + 2;
 	} else {
 		if( p_in != p_out )
 			memcpy( p_out, p_in, strlen );
@@ -692,22 +692,22 @@ static int
 quote_literal_buffer( void *_this, char *p_in, int strlen, char *p_out ){
 	char *ptr1;
 	char *ptr2;
-	int backslashs = 0;
+	int backslashes = 0;
 
 	/* count required backlashs */
 	for(ptr1 = p_in; ptr1 != p_in + strlen; ptr1++) {
 		if (*ptr1 == '\''){
-			backslashs++;
+			backslashes++;
 		}
 	}
 
 	ptr1 = p_in + strlen;
-	ptr2 = p_out + strlen + backslashs + 2;
+	ptr2 = p_out + strlen + backslashes + 2;
 	/* Write end quote */
 	*--ptr2 = '\'';
 
 	/* Then store the escaped string on the final position, walking
-		* right to left, until all backslashs are placed. */
+		* right to left, until all backslashes are placed. */
 	while( ptr1 != p_in ) {
 		*--ptr2 = *--ptr1;
 		if(*ptr2 == '\''){
@@ -716,7 +716,7 @@ quote_literal_buffer( void *_this, char *p_in, int strlen, char *p_out ){
 	}
 	/* Write start quote */
 	*p_out = '\'';
-	return strlen + backslashs + 2;
+	return strlen + backslashes + 2;
 }
 
 

--- a/lib/pg/basic_type_registry.rb
+++ b/lib/pg/basic_type_registry.rb
@@ -171,7 +171,7 @@ class PG::BasicTypeRegistry
 	include Checker
 
 	def initialize
-		# The key of these hashs maps to the `typname` column from the table pg_type.
+		# The key of these hashes maps to the `typname` column from the table pg_type.
 		@coders_by_name = []
 	end
 

--- a/lib/pg/connection.rb
+++ b/lib/pg/connection.rb
@@ -493,7 +493,7 @@ class PG::Connection
 	# See also #copy_data.
 	#
 	def put_copy_data(buffer, encoder=nil)
-		# sync_put_copy_data does a non-blocking attept to flush data.
+		# sync_put_copy_data does a non-blocking attempt to flush data.
 		until res=sync_put_copy_data(buffer, encoder)
 			# It didn't flush immediately and allocation of more buffering memory failed.
 			# Wait for all data sent by doing a blocking flush.

--- a/spec/helpers/scheduler.rb
+++ b/spec/helpers/scheduler.rb
@@ -196,7 +196,7 @@ class Scheduler
 
 		Fiber.yield
 	ensure
-		# Remove from @waiting in the case event occured before the timeout expired:
+		# Remove from @waiting in the case event occurred before the timeout expired:
 		@waiting.delete(fiber) if duration
 		@readable.delete(io) if readable
 		@writable.delete(io) if writable

--- a/spec/pg/connection_spec.rb
+++ b/spec/pg/connection_spec.rb
@@ -414,7 +414,7 @@ describe PG::Connection do
 		uri = "host=::1,::1,127.0.0.1 port=#{@port_down},#{@port},#{@port} dbname=postgres user=testusermd5 password=wrong"
 		error_match = if RUBY_PLATFORM=~/mingw|mswin/
 			# It's a long standing issue of libpq, that the error text is not correctly returned when both client and server are running on Windows.
-			# Instead a "Connection refused" is retured.
+			# Instead a "Connection refused" is returned.
 			/authenti.*testusermd5|Connection refused|server closed the connection unexpectedly/i
 		else
 			/authenti.*testusermd5/i
@@ -1705,7 +1705,7 @@ describe PG::Connection do
 		conn.close
 	end
 
-	it "refreshs DNS address while conn.reset", :without_transaction, :ipv6 do
+	it "refreshes DNS address while conn.reset", :without_transaction, :ipv6 do
 		set_etc_hosts "::1"
 		conn = described_class.connect( "postgres://rubypg_test/test" )
 		conn.exec("select 1")
@@ -2071,7 +2071,7 @@ describe PG::Connection do
 		end
 
 		describe "send_flush_request" do
-			it "flushs all results" do
+			it "flushes all results" do
 				@conn.enter_pipeline_mode
 				@conn.send_query_params "select 1", []
 				@conn.send_flush_request

--- a/spec/pg/result_spec.rb
+++ b/spec/pg/result_spec.rb
@@ -322,7 +322,7 @@ describe PG::Result do
 	it "encapsulates errors in a PG::Error object" do
 		exception = nil
 		begin
-			@conn.exec( "SELECT * FROM nonexistant_table" )
+			@conn.exec( "SELECT * FROM nonexistent_table" )
 		rescue PG::Error => err
 			exception = err
 		end
@@ -334,7 +334,7 @@ describe PG::Result do
 		expect( result.error_field(PG::PG_DIAG_SQLSTATE) ).to eq( '42P01' )
 		expect(
 			result.error_field(PG::PG_DIAG_MESSAGE_PRIMARY)
-		).to eq( 'relation "nonexistant_table" does not exist' )
+		).to eq( 'relation "nonexistent_table" does not exist' )
 		expect( result.error_field(PG::PG_DIAG_MESSAGE_DETAIL) ).to be_nil()
 		expect( result.error_field(PG::PG_DIAG_MESSAGE_HINT) ).to be_nil()
 		expect( result.error_field(PG::PG_DIAG_STATEMENT_POSITION) ).to eq( '15' )
@@ -353,7 +353,7 @@ describe PG::Result do
 	it "encapsulates PG_DIAG_SEVERITY_NONLOCALIZED error in a PG::Error object", :postgresql_96 do
 		result = nil
 		begin
-			@conn.exec( "SELECT * FROM nonexistant_table" )
+			@conn.exec( "SELECT * FROM nonexistent_table" )
 		rescue PG::Error => err
 			result = err.result
 		end
@@ -627,11 +627,11 @@ describe PG::Result do
 	end
 
 	it "can be manually checked for failed result status (async API)" do
-		@conn.send_query( "SELECT * FROM nonexistant_table" )
+		@conn.send_query( "SELECT * FROM nonexistent_table" )
 		res = @conn.get_result
 		expect {
 			res.check
-		}.to raise_error( PG::Error, /relation "nonexistant_table" does not exist/ )
+		}.to raise_error( PG::Error, /relation "nonexistent_table" does not exist/ )
 	end
 
 	it "can return the values of a single field" do
@@ -661,20 +661,20 @@ describe PG::Result do
 		expect{ res.tuple("x") }.to raise_error(TypeError)
 	end
 
-	it "raises a proper exception for a nonexistant table" do
+	it "raises a proper exception for a nonexistent table" do
 		expect {
-			@conn.exec( "SELECT * FROM nonexistant_table" )
-		}.to raise_error( PG::UndefinedTable, /relation "nonexistant_table" does not exist/ )
+			@conn.exec( "SELECT * FROM nonexistent_table" )
+		}.to raise_error( PG::UndefinedTable, /relation "nonexistent_table" does not exist/ )
 	end
 
 	it "raises a more generic exception for an unknown SQLSTATE" do
 		old_error = PG::ERROR_CLASSES.delete('42P01')
 		begin
 			expect {
-				@conn.exec( "SELECT * FROM nonexistant_table" )
+				@conn.exec( "SELECT * FROM nonexistent_table" )
 			}.to raise_error{|error|
 				expect( error ).to be_an_instance_of(PG::SyntaxErrorOrAccessRuleViolation)
-				expect( error.to_s ).to match(/relation "nonexistant_table" does not exist/)
+				expect( error.to_s ).to match(/relation "nonexistent_table" does not exist/)
 			}
 		ensure
 			PG::ERROR_CLASSES['42P01'] = old_error
@@ -686,10 +686,10 @@ describe PG::Result do
 		old_error2 = PG::ERROR_CLASSES.delete('42')
 		begin
 			expect {
-				@conn.exec( "SELECT * FROM nonexistant_table" )
+				@conn.exec( "SELECT * FROM nonexistent_table" )
 			}.to raise_error{|error|
 				expect( error ).to be_an_instance_of(PG::ServerError)
-				expect( error.to_s ).to match(/relation "nonexistant_table" does not exist/)
+				expect( error.to_s ).to match(/relation "nonexistent_table" does not exist/)
 			}
 		ensure
 			PG::ERROR_CLASSES['42P01'] = old_error1
@@ -697,10 +697,10 @@ describe PG::Result do
 		end
 	end
 
-	it "raises a proper exception for a nonexistant schema" do
+	it "raises a proper exception for a nonexistent schema" do
 		expect {
-			@conn.exec( "DROP SCHEMA nonexistant_schema" )
-		}.to raise_error( PG::InvalidSchemaName, /schema "nonexistant_schema" does not exist/ )
+			@conn.exec( "DROP SCHEMA nonexistent_schema" )
+		}.to raise_error( PG::InvalidSchemaName, /schema "nonexistent_schema" does not exist/ )
 	end
 
 	it "the raised result is nil in case of a connection error" do

--- a/spec/pg/type_spec.rb
+++ b/spec/pg/type_spec.rb
@@ -1257,7 +1257,7 @@ describe "PG::Type derivations" do
 								.to eq( nil )
 					end
 
-					it "should raise an error at grabage COPY format" do
+					it "should raise an error at garbage COPY format" do
 						expect{ decoder.decode("123\t \0\\\t\\") }
 								.to raise_error(ArgumentError, /premature.*at position: 7$/)
 					end


### PR DESCRIPTION
Found via `codespell -L te,wronly,noes,nulll` and `typos --format brief`