### PR TITLE
Improved documentation for connection.copy_data on how to use a PG::TypeMapByColumn.

### DIFF
--- a/Contributors.rdoc
+++ b/Contributors.rdoc
@@ -1,4 +1,3 @@
-
 Thanks to all the great people that have contributed code, suggestions, and patches through the
 years. If you contribute a patch, please include a patch for this file that adds your name to the
 list.
@@ -43,4 +42,5 @@ list.
 * Chris White <cwprogram@live.com>
 * Aaron Patterson <aaron.patterson@gmail.com>
 * Tim Felgentreff <timfelgentreff@gmail.com>
+* Daniel Lo <wilburlo@gmail.com>
 

--- a/lib/pg/connection.rb
+++ b/lib/pg/connection.rb
@@ -168,10 +168,18 @@ class PG::Connection
 	#
 	# Also PG::BinaryEncoder::CopyRow can be used to send data in binary format to the server.
 	# In this case copy_data generates the header and trailer data automatically:
-	#   enco = PG::BinaryEncoder::CopyRow.new
+	# A complete list of column types can be found under PG::BinaryEncoder documentation.
+	#   type_map = PG::TypeMapByColumn.new([
+	#     PG::BinaryEncoder::String.new,
+	#     PG::BinaryEncoder::String.new,
+	#     PG::BinaryEncoder::String.new,
+	#     PG::BinaryEncoder::String.new,
+	#     PG::BinaryEncoder::TimeStampUtc.new,
+	#   ])
+	#   enco = PG::BinaryEncoder::CopyRow.new( type_map: type_map )
 	#   conn.copy_data "COPY my_table FROM STDIN (FORMAT binary)", enco do
-	#     conn.put_copy_data ['some', 'data', 'to', 'copy']
-	#     conn.put_copy_data ['more', 'data', 'to', 'copy']
+	#     conn.put_copy_data ['some', 'data', 'to', 'copy', Time.now]
+	#     conn.put_copy_data ['more', 'data', 'to', 'copy', Time.now]
 	#   end
 	#
 	# Example with CSV output format:


### PR DESCRIPTION
Here is how you can use the connection.copy_row type map to insert binary data. 

Understanding PG::TypeMapByColumn is essential, and having an example provides a good starting point for how to convert the data.

I found it pretty hard to find information on example construction for a type map.  Incidentally, ChatGPT completely screws this up.
