### PR TITLE
Don't print a warning when bigdecimal is required on ruby-3.4+

### DIFF
--- a/ext/pg_text_decoder.c
+++ b/ext/pg_text_decoder.c
@@ -174,7 +174,7 @@ pg_text_dec_numeric(t_pg_coder *conv, const char *val, int len, int tuple, int f
 static VALUE
 init_pg_text_decoder_numeric(VALUE rb_mPG_TextDecoder)
 {
-	rb_require("bigdecimal");
+	rb_funcall(rb_mPG, rb_intern("require_bigdecimal_without_warning"), 0);
 	s_id_BigDecimal = rb_intern("BigDecimal");
 
 	/* dummy = rb_define_class_under( rb_mPG_TextDecoder, "Numeric", rb_cPG_SimpleDecoder ); */

--- a/ext/pg_text_encoder.c
+++ b/ext/pg_text_encoder.c
@@ -377,7 +377,7 @@ init_pg_text_encoder_numeric(VALUE rb_mPG_TextDecoder)
 {
 	s_str_F = rb_str_freeze(rb_str_new_cstr("F"));
 	rb_global_variable(&s_str_F);
-	rb_require("bigdecimal");
+	rb_funcall(rb_mPG, rb_intern("require_bigdecimal_without_warning"), 0);
 	s_cBigDecimal = rb_const_get(rb_cObject, rb_intern("BigDecimal"));
 
 	/* dummy = rb_define_class_under( rb_mPG_TextEncoder, "Numeric", rb_cPG_SimpleEncoder ); */

--- a/lib/pg.rb
+++ b/lib/pg.rb
@@ -126,4 +126,14 @@ module PG
 		Warning.extend(TruffleFixWarn)
 	end
 
+	# Ruby-3.4+ prints a warning, if bigdecimal is required but not in the Gemfile.
+	# But it's a false positive, since we enable bigdecimal depending features only if it's available.
+	# And most people don't need these features.
+	def self.require_bigdecimal_without_warning
+		oldverb, $VERBOSE = $VERBOSE, nil
+		require "bigdecimal"
+	ensure
+		$VERBOSE = oldverb
+	end
+
 end # module PG

--- a/lib/pg/basic_type_map_for_queries.rb
+++ b/lib/pg/basic_type_map_for_queries.rb
@@ -167,7 +167,7 @@ class PG::BasicTypeMapForQueries < PG::TypeMapByClass
 	end
 
 	begin
-		require "bigdecimal"
+		PG.require_bigdecimal_without_warning
 		has_bigdecimal = true
 	rescue LoadError
 	end

--- a/lib/pg/basic_type_registry.rb
+++ b/lib/pg/basic_type_registry.rb
@@ -233,7 +233,7 @@ class PG::BasicTypeRegistry
 		alias_type    0, 'oid',  'int2'
 
 		begin
-			require "bigdecimal"
+			PG.require_bigdecimal_without_warning
 			register_type 0, 'numeric', PG::TextEncoder::Numeric, PG::TextDecoder::Numeric
 		rescue LoadError
 		end

--- a/spec/helpers.rb
+++ b/spec/helpers.rb
@@ -711,7 +711,7 @@ RSpec.configure do |config|
 	config.filter_run_excluding( :ipv6 ) if Addrinfo.getaddrinfo("localhost", nil, nil, :STREAM).size < 2
 	config.filter_run_excluding( :ractor ) unless defined?(Ractor)
 	begin
-		require "bigdecimal"
+		PG.require_bigdecimal_without_warning
 	rescue LoadError
 		config.filter_run_excluding( :bigdecimal )
 	end


### PR DESCRIPTION
Ruby-3.4+ prints a warning, if bigdecimal is required but not in the Gemfile. But it's a false positive, since we enable bigdecimal depending features only if it's available. And most people don't need these features.

Fixes #569