### PR TITLE
CI: Fix appveyor build by switching to x64 platform

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -38,5 +38,5 @@ on_failure:
 environment:
   matrix:
     - ruby_version: "head"
-      RUBYDOWNLOAD: x86
+      RUBYDOWNLOAD: x64
     - ruby_version: "30-x64"


### PR DESCRIPTION
It failed with:
  Command executed with exception: error: target not found: mingw-w64-i686-postgresql