### PR TITLE
Fix to refer Float::NAN and Float::INFINITY

### DIFF
--- a/ext/pg_text_decoder.c
+++ b/ext/pg_text_decoder.c
@@ -973,9 +973,9 @@ init_pg_text_decoder(void)
 	s_id_utc = rb_intern("utc");
 	s_id_getlocal = rb_intern("getlocal");
 
-	s_nan = rb_eval_string("0.0/0.0");
+	s_nan = rb_const_get(rb_cFloat, rb_intern("NAN"));
 	rb_global_variable(&s_nan);
-	s_pos_inf = rb_eval_string("1.0/0.0");
+	s_pos_inf = rb_const_get(rb_cFloat, rb_intern("INFINITY"));
 	rb_global_variable(&s_pos_inf);
 	s_neg_inf = rb_eval_string("-1.0/0.0");
 	rb_global_variable(&s_neg_inf);


### PR DESCRIPTION
Currently, ruby-pg returns evaluated value of `0.0/0.0` when a query search result contains NaN, instead of `Float:: NAN`. This behavior is strange and not intuitive, especially when user checks values in query by `val.equal?(Float::NAN)` (faster) instead of `val.is_a?(Float) && val.nan?` (slower).

This commit fixes it to return `Float::NAN`.
Similarly, fix to use `Float::INFINITY` instead of `1.0/0.0`.