### PR TITLE
Add default decoder for anonymous record types to BasicTypeRegistry

### DIFF
--- a/lib/pg/basic_type_registry.rb
+++ b/lib/pg/basic_type_registry.rb
@@ -278,6 +278,7 @@ class PG::BasicTypeRegistry
 		register_type 0, 'inet', PG::TextEncoder::Inet, PG::TextDecoder::Inet
 		alias_type 0, 'cidr', 'inet'
 
+		register_type 0, 'record', PG::TextEncoder::Record, PG::TextDecoder::Record
 
 
 		register_type 1, 'int2', PG::BinaryEncoder::Int2, PG::BinaryDecoder::Integer

--- a/spec/pg/basic_type_map_for_results_spec.rb
+++ b/spec/pg/basic_type_map_for_results_spec.rb
@@ -317,6 +317,16 @@ describe 'Basic type mapping' do
 			end
 
 			[0].each do |format|
+				it "should do format #{format} anonymous record type conversions" do
+					res = @conn.exec_params( "SELECT 6, ROW(123, 'str', true, null), 7
+						", [], format )
+					expect( res.getvalue(0,0) ).to eq( 6 )
+					expect( res.getvalue(0,1) ).to eq( ["123", "str", "t", nil] )
+					expect( res.getvalue(0,2) ).to eq( 7 )
+				end
+			end
+
+			[0].each do |format|
 				it "should do format #{format} inet type conversions" do
 					vals = [
 						'1.2.3.4',


### PR DESCRIPTION
The PostgreSQL server just sends the generic OID 2249 for generic record/composite types in query results like:
```SQL
  SELECT row(123, 'str', true, null)
```

Since we don't get the OIDs of the record items, we can not properly decode them. Nevertheless it's helpful to decode at least with the default type map and decode all items to an array of strings like so:
```ruby
c.exec("SELECT 6, row(123, 'str', true, null), 7").values
 => [[6, ["123", "str", "t", nil], 7]]
```

instead of:
```ruby
 => [[6, "(123,str,t,)", 7]] 
```

Related to #578