### PR TITLE
Save connection options for conn.reset

### DIFF
--- a/ext/pg_connection.c
+++ b/ext/pg_connection.c
@@ -264,6 +264,7 @@ pgconn_s_allocate( VALUE klass )
 	RB_OBJ_WRITE(self, &this->decoder_for_get_copy_data, Qnil);
 	RB_OBJ_WRITE(self, &this->trace_stream, Qnil);
 	rb_ivar_set(self, rb_intern("@calls_to_put_copy_data"), INT2FIX(0));
+	rb_ivar_set(self, rb_intern("@iopts_for_reset"), Qnil);
 
 	return self;
 }

--- a/spec/helpers.rb
+++ b/spec/helpers.rb
@@ -678,8 +678,8 @@ EOT
 	end
 
 	# Append or change 'rubypg_test' host entry in /etc/hosts to a given IP address
-	def set_etc_hosts(hostaddr)
-		system "sudo --non-interactive sed -i '/.* rubypg_test$/{h;s/.*/#{hostaddr} rubypg_test/};${x;/^$/{s//#{hostaddr} rubypg_test/;H};x}' /etc/hosts" or skip("unable to change /etc/hosts file")
+	def set_etc_hosts(hostaddr, hostname)
+		system "sudo --non-interactive sed -i '/.* #{hostname}$/{h;s/.*/#{hostaddr} #{hostname}/};${x;/^$/{s//#{hostaddr} #{hostname}/;H};x}' /etc/hosts" or skip("unable to change /etc/hosts file")
 	end
 end
 

--- a/spec/pg/connection_spec.rb
+++ b/spec/pg/connection_spec.rb
@@ -1728,15 +1728,15 @@ describe PG::Connection do
 	end
 
 	it "refreshes DNS address while conn.reset", :without_transaction, :ipv6 do
-		set_etc_hosts "::1"
-		conn = described_class.connect( "postgres://rubypg_test/test" )
+		set_etc_hosts "::1", "rubypg_test1"
+		conn = described_class.connect( "postgres://rubypg_test1/test" )
 		conn.exec("select 1")
 
-		set_etc_hosts "127.0.0.1"
+		set_etc_hosts "127.0.0.1", "rubypg_test1"
 		conn.reset
 		conn.exec("select 1")
 
-		set_etc_hosts "::2"
+		set_etc_hosts "::2", "rubypg_test1"
 		expect do
 			conn.reset
 			conn.exec("select 1")


### PR DESCRIPTION
Commit 016c17c9c9bbc51bf5fab2087ad485367c789118 introduced a regression, that leads to a host list duplication every time `conn.reset` is used.

Since the hosts are duplicated when resolve_hosts is called, the `conn.coninfo_hash` can not be used. So the fix is to store the original hash of connection options for later use in conn.reset .

Fixes #586