### PR TITLE
Remove raising conect_timeout from 1 to 2 seconds

### DIFF
--- a/lib/pg/connection.rb
+++ b/lib/pg/connection.rb
@@ -653,8 +653,6 @@ class PG::Connection
 		# Track the progress of the connection, waiting for the socket to become readable/writable before polling it
 
 		if (timeo = conninfo_hash[:connect_timeout].to_i) && timeo > 0
-			# Lowest timeout is 2 seconds - like in libpq
-			timeo = [timeo, 2].max
 			host_count = conninfo_hash[:host].to_s.count(",") + 1
 			stop_time = timeo * host_count + Process.clock_gettime(Process::CLOCK_MONOTONIC)
 		end

--- a/spec/pg/connection_spec.rb
+++ b/spec/pg/connection_spec.rb
@@ -377,7 +377,7 @@ describe PG::Connection do
 				end
 			end
 
-			expect( Time.now - start_time ).to be_between(1.9, 10).inclusive
+			expect( Time.now - start_time ).to be_between(0.9, 10).inclusive
 		end
 	end
 


### PR DESCRIPTION
This will be removed in libpq of PostgreSQL-17 by this commit:
  https://github.com/postgres/postgres/commit/105024a47238e33647d346264b4f6fe68a7287ed
The adjustment of connect_timeout from 1 to 2 seconds was anyway only relevant due to libpq's internal rounding, which doesn't apply to ruby.