### PR TITLE
Exclude CI files from built gem

### DIFF
--- a/pg.gemspec
+++ b/pg.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
   # The `git ls-files -z` loads the files in the RubyGem that have been added into git.
   spec.files = Dir.chdir(File.expand_path(__dir__)) do
     `git ls-files -z`.split("\x0").reject do |f|
-      f.match(%r{\A(?:test|spec|features|translation|\.github|\.travis|\.appveyor)})
+      f.match(%r{\A(?:test|spec|features|translation|\.)})
     end
   end
   spec.extensions    = ["ext/extconf.rb"]

--- a/pg.gemspec
+++ b/pg.gemspec
@@ -23,7 +23,9 @@ Gem::Specification.new do |spec|
   # Specify which files should be added to the gem when it is released.
   # The `git ls-files -z` loads the files in the RubyGem that have been added into git.
   spec.files = Dir.chdir(File.expand_path(__dir__)) do
-    `git ls-files -z`.split("\x0").reject { |f| f.match(%r{\A(?:test|spec|features|translation)/}) }
+    `git ls-files -z`.split("\x0").reject do |f|
+      f.match(%r{\A(?:test|spec|features|translation|\.github|\.travis|\.appveyor)})
+    end
   end
   spec.extensions    = ["ext/extconf.rb"]
   spec.require_paths = ["lib"]


### PR DESCRIPTION
Security inspection of some users or even their clients can be confused by finding out unknown YAML files with `Download` instructions inside final production releases. We can just get rid of them.

Also Regex is fixed now, `/` before closing `)` was breaking.