### PR TITLE
Ignore `test_trace.out` file for git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@
 /vendor/
 /lib/libpq.dll
 /lib/pg/postgresql_lib_path.rb
+/test_trace.out


### PR DESCRIPTION
It's an artifact after `rake test`, and should not be tracked by git.