### PR TITLE
Enable thread safety in static OpenSSL build

### DIFF
--- a/Rakefile.cross
+++ b/Rakefile.cross
@@ -118,7 +118,7 @@ class CrossLibrary < OpenStruct
 		self.cmd_prelude = [
 			"env",
 			"CROSS_COMPILE=#{host_platform}-",
-			"CFLAGS=-DDSO_WIN32",
+			"CFLAGS=-DDSO_WIN32 -DOPENSSL_THREADS",
 		]
 
 
@@ -126,7 +126,7 @@ class CrossLibrary < OpenStruct
 		file openssl_makefile => static_openssl_builddir do |t|
 			chdir( static_openssl_builddir ) do
 				cmd = cmd_prelude.dup
-				cmd << "./Configure" << "-static" << openssl_config
+				cmd << "./Configure" << "threads" << "-static" << openssl_config
 
 				run( *cmd )
 			end
@@ -192,7 +192,7 @@ class CrossLibrary < OpenStruct
 				cmd << "CFLAGS=-L#{static_openssl_builddir}"
 				cmd << "LDFLAGS=-L#{static_openssl_builddir}"
 				cmd << "LDFLAGS_SL=-L#{static_openssl_builddir}"
-				cmd << "LIBS=-lwsock32 -lgdi32 -lws2_32 -lcrypt32"
+				cmd << "LIBS=-lssl -lwsock32 -lgdi32 -lws2_32 -lcrypt32"
 				cmd << "CPPFLAGS=-I#{static_openssl_builddir}/include"
 
 				run( *cmd )

--- a/spec/pg/connection_spec.rb
+++ b/spec/pg/connection_spec.rb
@@ -1556,6 +1556,17 @@ describe PG::Connection do
 		end
 	end
 
+	it "can connect concurrently in parallel threads", :postgresql_95 do
+		res = 5.times.map do |idx|
+			Thread.new do
+				PG.connect(@conninfo) do |conn|
+					[conn.ssl_in_use?, conn.exec("select 82").getvalue(0, 0)]
+				end
+			end
+		end.map(&:value)
+		expect( res ).to eq( [[true, "82"]] * 5 )
+	end
+
 	describe "deprecated password encryption method" do
 		it "can encrypt password for a given user" do
 			expect( described_class.encrypt_password("postgres", "postgres") ).to match( /\S+/ )


### PR DESCRIPTION
This is disabled by default due to the `-static` option. The `thread` doesn't work with `-static`, that's why it is enabled by `-DOPENSSL_THREADS`. The thread functions are used in libcrypto.a and libssl.a but only defined in libssl.a.

Fixes #595