### PR TITLE
Remove workarounds for PostgreSQL static build

### DIFF
--- a/Rakefile.cross
+++ b/Rakefile.cross
@@ -202,18 +202,6 @@ class CrossLibrary < OpenStruct
 
 		# make libpq.dll
 		task postgresql_lib => [ postgresql_global_makefile ] do |t|
-			# Work around missing dependency to libcommon in PostgreSQL-9.4.0
-			chdir( static_postgresql_srcdir + "common" ) do
-				sh 'make', "-j#{NUM_CPUS}"
-			end
-			# Work around missing dependency to errorcodes.h in PostgreSQL-17.0
-			chdir( static_postgresql_srcdir + "backend" + "utils" ) do
-				sh 'make', "-j#{NUM_CPUS}"
-			end
-			chdir( static_postgresql_srcdir + "port" ) do
-				sh 'make', "-j#{NUM_CPUS}"
-			end
-
 			chdir( postgresql_lib.dirname ) do
 				sh 'make',
 					"-j#{NUM_CPUS}",


### PR DESCRIPTION
They seem to be no longer necessary.