### PR TITLE
Initial pass adding AWS IAM Authentication

### DIFF
--- a/Manifest.txt
+++ b/Manifest.txt
@@ -43,6 +43,7 @@ ext/vc/pg.sln
 ext/vc/pg_18/pg.vcproj
 ext/vc/pg_19/pg_19.vcproj
 lib/pg.rb
+lib/pg/aws_iam_auth.rb
 lib/pg/basic_type_mapping.rb
 lib/pg/binary_decoder.rb
 lib/pg/coder.rb

--- a/lib/pg.rb
+++ b/lib/pg.rb
@@ -110,6 +110,7 @@ module PG
 	require 'pg/exceptions'
 	require 'pg/coder'
 	require 'pg/type_map_by_column'
+	require 'pg/aws_iam_auth'
 	require 'pg/connection'
 	require 'pg/result'
 	require 'pg/tuple'

--- a/lib/pg/aws_iam_auth.rb
+++ b/lib/pg/aws_iam_auth.rb
@@ -1,0 +1,70 @@
+# -*- ruby -*-
+# frozen_string_literal: true
+
+require 'singleton'
+
+module PG
+  # Generates and caches AWS IAM Authentication tokens to use in place of PostgreSQL user passwords
+  class AwsIamAuth
+    include Singleton
+    attr_reader :mutex
+    attr_accessor :passwords
+
+    # Tokens are valid for up to 15 minutes.
+    # We will assume ours expire in 14 minutes to be safe.
+    TOKEN_EXPIRES_IN = (60 * 14) # 14 minutes
+
+    def initialize
+      begin
+        require 'aws-sdk-rds'
+      rescue LoadError
+        raise LoadError, "gem aws-sdk-rds was not found.  Please add this gem to your bundle to use AWS IAM Authentication."
+      end
+
+      @mutex = Mutex.new
+      # Key identifies a unique set of authentication parameters
+      # Value is a Hash
+      # :password is the token value
+      # :expires_at is (just before) the token was generated plus 14 minutes
+      @passwords = {}
+      instance_credentials = Aws::InstanceProfileCredentials.new
+      @generator = Aws::RDS::AuthTokenGenerator.new(:credentials => instance_credentials)
+    end
+
+    def password(user, host, port, region)
+      params = to_params(user, host, port, region)
+      key = key_from_params(params)
+      passwd = nil
+      AwsIamAuth.instance.mutex.synchronize do
+        begin
+          passwd = @passwords[key][:password] if @passwords.dig(key, :password) && Time.now.utc < @passwords.dig(key, :expires_at)
+        rescue KeyError
+          passwd = nil
+        end
+      end
+      return passwd unless passwd.nil?
+
+      AwsIamAuth.instance.mutex.synchronize do
+        @passwords[key] = {}
+        @passwords[key][:expires_at] = Time.now.utc + TOKEN_EXPIRES_IN
+        @passwords[key][:password] = password_from_iam(params)
+      end
+    end
+
+    def password_from_iam(params)
+      @generator.auth_token(params)
+    end
+
+    def to_params(user, host, port, region)
+      params = {}
+      params[:region] = region
+      params[:endpoint] = "#{host}:#{port}"
+      params[:user_name] = user
+      params
+    end
+
+    def key_from_params(params)
+      "#{params[:user_name]}/#{params[:endpoint]}/#{params[:region]}"
+    end
+  end
+end


### PR DESCRIPTION
This adds AWS IAM Authentication, which replaces the `password` parameter normally provided with a dynamically generated, short-lived authetication token. The authentication token (password) will be fetched from IAM and cached for the next 14 minutes (tokens expire in 15 minutes).  These can then be reused by all new connections until it expires, at which point a new token will be fetched when next needed.

To allow for multiple configurations to multiple servers, the cache is keyed by database username, host name, port, and region.

To use, specify in the environment variables:
- PG_USE_IAM_AUTHENTICATION=true
- AWS_REGION=us-east-1  or whatever your AWS region is

As prerequisites, you must enable IAM authentication on the RDS instance, create an IAM policy, attach the policy to the target IAM user or role, create the database user set to use the AWS Authentication Plugin, and then run your ruby code using that user or role.  See
https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/UsingWithRDS.IAMDBAuth.Connecting.html for details on these steps.

You must include the aws-sdk-rds gem in your bundle to use this feature.  A LoadError is raised if the functionality is tried to be used but that gem is not present.

The use of environment variables to invoke this functionality is unusual. You'd expect to able to put these on the postgres connection string.  However, only arguments valid to PostgreSQL itself are allowed on the connection string, and only this gem needs them.  If there's a better way, please advise.

Implements code in issue https://github.com/ged/ruby-pg/issues/602