### PR TITLE
Fix writing lots of data through the TcpGateScheduler

### DIFF
--- a/spec/helpers.rb
+++ b/spec/helpers.rb
@@ -594,7 +594,7 @@ EOT
 		# Run examples with gated scheduler
 		sched = Helpers::TcpGateScheduler.new(external_host: 'localhost', external_port: ENV['PGPORT'].to_i, debug: ENV['PG_DEBUG']=='1')
 		Fiber.set_scheduler(sched)
-		@conninfo_gate = @conninfo.gsub(/(^| )port=\d+/, " port=#{sched.internal_port} sslmode=disable")
+		@conninfo_gate = @conninfo.gsub(/(^| )port=\d+/, " port=#{sched.internal_port}")
 
 		# Run examples with default scheduler
 		#Fiber.set_scheduler(Helpers::Scheduler.new)
@@ -640,7 +640,7 @@ EOT
 	def gate_setup
 		# Run examples with gate
 		gate = Helpers::TcpGateSwitcher.new(external_host: 'localhost', external_port: ENV['PGPORT'].to_i, debug: ENV['PG_DEBUG']=='1')
-		@conninfo_gate = @conninfo.gsub(/(^| )port=\d+/, " port=#{gate.internal_port} sslmode=disable")
+		@conninfo_gate = @conninfo.gsub(/(^| )port=\d+/, " port=#{gate.internal_port}")
 
 		# Run examples without gate
 		#@conninfo_gate = @conninfo

--- a/spec/helpers/tcp_gate_scheduler.rb
+++ b/spec/helpers/tcp_gate_scheduler.rb
@@ -148,12 +148,12 @@ class TcpGateScheduler < Scheduler
 						rescue IO::WaitReadable, Errno::EINTR
 							@internal_io.wait_readable
 							retry
-						rescue EOFError, Errno::ECONNRESET
+						rescue EOFError, Errno::ECONNRESET, Errno::ECONNABORTED
 							puts "write_eof from #{write_fds}"
 							@external_io.close_write
 							break
 						end
-						break if @transfer_until != :eof && (!read_str || read_str.bytesize < len)
+						break if @transfer_until != :eof && (!read_str || read_str.empty?)
 					end
 					@pending_write = false
 				end


### PR DESCRIPTION
3 tests failed after upgrade to Linux-6.10 due to starvation of data transfer in write direction. This was because we stopped the transfer when less than the requested size could be read. Stopping only when no data at all was read fixes this issue.

It also turned out, that the same issue led to starvation of SSL encrypted traffix. So this patch re-enables SSL for scheduler tests which was disabled in commit f270b714c66690b18a0e28bf0af667212cb00bee

Fixes #601