### PR TITLE
Initialize "intermediate" VALUE for encoding

### DIFF
--- a/ext/pg_coder.c
+++ b/ext/pg_coder.c
@@ -175,7 +175,7 @@ static VALUE
 pg_coder_encode(int argc, VALUE *argv, VALUE self)
 {
 	VALUE res;
-	VALUE intermediate;
+	VALUE intermediate = Qnil;
 	VALUE value;
 	int len, len2;
 	int enc_idx;
@@ -212,8 +212,6 @@ pg_coder_encode(int argc, VALUE *argv, VALUE self)
 			rb_obj_classname( self ), len, len2 );
 	}
 	rb_str_set_len( res, len2 );
-
-	RB_GC_GUARD(intermediate);
 
 	return res;
 }

--- a/ext/pg_connection.c
+++ b/ext/pg_connection.c
@@ -1297,7 +1297,7 @@ alloc_query_params(struct query_params_data *paramsData)
 				paramsData->lengths[i] = 0;
 			} else {
 				t_pg_coder_enc_func enc_func = pg_coder_enc_func( conv );
-				VALUE intermediate;
+				VALUE intermediate = Qnil;
 
 				/* 1st pass for retiving the required memory space */
 				int len = enc_func(conv, param_value, NULL, &intermediate, paramsData->enc_idx);
@@ -1337,8 +1337,6 @@ alloc_query_params(struct query_params_data *paramsData)
 						required_pool_size += len;
 					}
 				}
-
-				RB_GC_GUARD(intermediate);
 			}
 		}
 	}
@@ -2566,7 +2564,7 @@ pgconn_sync_put_copy_data(int argc, VALUE *argv, VALUE self)
 	VALUE value;
 	VALUE buffer = Qnil;
 	VALUE encoder;
-	VALUE intermediate;
+	VALUE intermediate = Qnil;
 	t_pg_coder *p_coder = NULL;
 
 	rb_scan_args( argc, argv, "11", &value, &encoder );
@@ -2605,7 +2603,6 @@ pgconn_sync_put_copy_data(int argc, VALUE *argv, VALUE self)
 	if(ret == -1)
 		pg_raise_conn_error( rb_ePGerror, self, "%s", PQerrorMessage(this->pgconn));
 
-	RB_GC_GUARD(intermediate);
 	RB_GC_GUARD(buffer);
 
 	return (ret) ? Qtrue : Qfalse;

--- a/ext/pg_text_encoder.c
+++ b/ext/pg_text_encoder.c
@@ -231,7 +231,7 @@ pg_text_enc_integer(t_pg_coder *this, VALUE value, char *out, VALUE *intermediat
  *
  */
 static int
-pg_text_enc_float(t_pg_coder *conv, VALUE value, char *out, VALUE *intermediate, int enc_idx)
+pg_text_enc_float(t_pg_coder *conv, VALUE value, char *out, VALUE *intermediate1, int enc_idx)
 {
 	if(out){
 		double dvalue = NUM2DBL(value);
@@ -239,7 +239,6 @@ pg_text_enc_float(t_pg_coder *conv, VALUE value, char *out, VALUE *intermediate,
 		int neg = 0;
 		int exp2i, exp10i, i;
 		unsigned long long ll, remainder, oldval;
-		VALUE intermediate;
 
 		/* Cast to the same strings as value.to_s . */
 		if( isinf(dvalue) ){
@@ -283,6 +282,7 @@ pg_text_enc_float(t_pg_coder *conv, VALUE value, char *out, VALUE *intermediate,
 
 		if( exp10i <= -5 || exp10i >= 15 ) {
 			/* Write the float in exponent format (1.23e45) */
+			VALUE intermediate;
 
 			/* write fraction digits from right to left */
 			for( i = MAX_DOUBLE_DIGITS; i > 1; i--){


### PR DESCRIPTION
It is no good practice to put uninitialized VALUEs into ruby array and it can lead to C/Java exceptions in Truffleruby. So better initialize them to nil.
Also remove the GC_GUARD, since it's not necessary.