### PR TITLE
Add Connection#send_pipeline_sync, async_pipeline_sync and release GVL at PQ(sendP|p)ipelineSync

### DIFF
--- a/.github/workflows/binary-gems.yml
+++ b/.github/workflows/binary-gems.yml
@@ -60,7 +60,7 @@ jobs:
           - os: windows-latest
             ruby: "2.7"
             platform: "x64-mingw32"
-            PGVERSION: 10.20-1-windows
+            PGVERSION: 16.6-1-windows-x64
 
     runs-on: ${{ matrix.os }}
     env:

--- a/.github/workflows/source-gem.yml
+++ b/.github/workflows/source-gem.yml
@@ -66,7 +66,7 @@ jobs:
             PGVER: "10"
           - os: ubuntu
             ruby: "truffleruby"
-            PGVER: "13"
+            PGVER: "14"
           - os: ubuntu
             ruby: "truffleruby-head"
             PGVER: "17"

--- a/ext/gvl_wrappers.c
+++ b/ext/gvl_wrappers.c
@@ -11,6 +11,10 @@ PGresult *PQclosePrepared(PGconn *conn, const char *stmtName){return NULL;}
 PGresult *PQclosePortal(PGconn *conn, const char *portalName){return NULL;}
 int PQsendClosePrepared(PGconn *conn, const char *stmtName){return 0;}
 int PQsendClosePortal(PGconn *conn, const char *portalName){return 0;}
+int PQsendPipelineSync(PGconn *conn){return 0;}
+#endif
+#ifndef HAVE_PQENTERPIPELINEMODE
+int PQpipelineSync(PGconn *conn){return 0;}
 #endif
 
 #ifdef ENABLE_GVL_UNLOCK

--- a/ext/gvl_wrappers.h
+++ b/ext/gvl_wrappers.h
@@ -208,6 +208,10 @@
 #define FOR_EACH_PARAM_OF_PQsendClosePortal(param) \
 	param(PGconn *, conn)
 
+#define FOR_EACH_PARAM_OF_PQpipelineSync(param)
+
+#define FOR_EACH_PARAM_OF_PQsendPipelineSync(param)
+
 #define FOR_EACH_PARAM_OF_PQsetClientEncoding(param) \
 	param(PGconn *, conn)
 
@@ -252,6 +256,8 @@
 	function(PQsendDescribePortal, GVL_TYPE_NONVOID, int, const char *, portal) \
 	function(PQsendClosePrepared, GVL_TYPE_NONVOID, int, const char *, stmt) \
 	function(PQsendClosePortal, GVL_TYPE_NONVOID, int, const char *, portal) \
+	function(PQpipelineSync, GVL_TYPE_NONVOID, int, PGconn *, conn) \
+	function(PQsendPipelineSync, GVL_TYPE_NONVOID, int, PGconn *, conn) \
 	function(PQsetClientEncoding, GVL_TYPE_NONVOID, int, const char *, encoding) \
 	function(PQisBusy, GVL_TYPE_NONVOID, int, PGconn *, conn) \
 	function(PQencryptPasswordConn, GVL_TYPE_NONVOID, char *, const char *, algorithm) \

--- a/spec/pg/connection_spec.rb
+++ b/spec/pg/connection_spec.rb
@@ -2173,6 +2173,11 @@ describe PG::Connection do
 					@conn.pipeline_sync
 				}.to raise_error(PG::Error){|err| expect(err).to have_attributes(connection: @conn) }
 			end
+
+			it "has send_pipeline_sync method", :postgresql_17 do
+				expect( @conn.respond_to?(:send_pipeline_sync) ).to be_truthy
+				expect( @conn.respond_to?(:async_pipeline_sync) ).to be_truthy
+			end
 		end
 
 		describe "send_flush_request" do


### PR DESCRIPTION
Also make `pipeline_sync` an alias for `sync_pipeline_sync` vs. `async_pipeline_sync`.

Now `send_pipeline_sync` and `flush` is used to notify IO waiting to the scheduler.