### PR TITLE
Add MINGW package dependency which is resolved by RubyInstaller

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -24,8 +24,6 @@ install:
 
         $env:PATH = 'C:/Program Files/PostgreSQL/' + $env:PGVER + '/bin;' + $env:PATH
         $env:PATH = 'C:/Program Files (x86)/PostgreSQL/' + $env:PGVER + '/bin;' + $env:PATH
-      } else {
-        c:/msys64/usr/bin/bash -lc "pacman -S --noconfirm --needed `${MINGW_PACKAGE_PREFIX}-postgresql"
       }
   - echo %PATH%
   - pg_config

--- a/pg.gemspec
+++ b/pg.gemspec
@@ -19,6 +19,8 @@ Gem::Specification.new do |spec|
   spec.metadata["source_code_uri"] = "https://github.com/ged/ruby-pg"
   spec.metadata["changelog_uri"] = "https://github.com/ged/ruby-pg/blob/master/History.md"
   spec.metadata["documentation_uri"] = "http://deveiate.org/code/pg"
+  # https://github.com/oneclick/rubyinstaller2/wiki/For-gem-developers#msys2-library-dependency
+  spec.metadata["msys2_mingw_dependencies"] = "postgresql"
 
   # Specify which files should be added to the gem when it is released.
   # The `git ls-files -z` loads the files in the RubyGem that have been added into git.


### PR DESCRIPTION
There is no package with contains libpq only, but the postgresql package now has less depencies than it had in the past. Especially python and perl are optional dependecies now, so that the install size is acceptable:

```
Pakete (5) mingw-w64-clang-aarch64-icu-75.1-2  mingw-w64-clang-aarch64-lz4-1.10.0-1
           mingw-w64-clang-aarch64-openssl-3.4.0-1  winpty-0.4.3-3  mingw-w64-clang-aarch64-postgresql-17.2-1

Gesamtgröße des Downloads:              40,09 MiB
Gesamtgröße der installierten Pakete:  198,79 MiB
```
