### PR TITLE
try the next host on connnect_timeout

### DIFF
--- a/spec/helpers.rb
+++ b/spec/helpers.rb
@@ -475,6 +475,17 @@ EOT
 		end
 	end
 
+	class ListenSocket
+		attr_reader :port
+		def initialize(host = '0.0.0.0', accept: true)
+			TCPServer.open( host, 0 ) do |serv|
+
+				@port = serv.local_address.ip_port
+				yield self
+			end
+		end
+	end
+
 	def check_for_lingering_connections( conn )
 		conn.exec( "SELECT * FROM pg_stat_activity" ) do |res|
 			conns = res.find_all {|row| row['pid'].to_i != conn.backend_pid && ["client backend", nil].include?(row["backend_type"]) }

--- a/spec/pg/connection_spec.rb
+++ b/spec/pg/connection_spec.rb
@@ -374,10 +374,10 @@ describe PG::Connection do
 			start_time = Time.now
 			expect {
 				described_class.connect(
-																host: 'localhost',
-																port: 54320,
-																connect_timeout: 1,
-																dbname: "test")
+					host: 'localhost',
+					port: 54320,
+					connect_timeout: 1,
+					dbname: "test")
 			}.to raise_error do |error|
 				expect( error ).to be_an( PG::ConnectionBad )
 				expect( error.message ).to match( /timeout expired/ )
@@ -387,6 +387,20 @@ describe PG::Connection do
 				end
 			end
 
+			expect( Time.now - start_time ).to be_between(0.9, 10).inclusive
+		end
+	end
+
+	it "succeeds with second host after connect_timeout" do
+		TCPServer.open( 'localhost', 54320 ) do |serv|
+			start_time = Time.now
+			conn = described_class.connect(
+				host: 'localhost,localhost,localhost',
+				port: "54320,#{@port},54320",
+				connect_timeout: 1,
+				dbname: "test")
+
+			expect( conn.port ).to eq( @port )
 			expect( Time.now - start_time ).to be_between(0.9, 10).inclusive
 		end
 	end

--- a/spec/pg/connection_spec.rb
+++ b/spec/pg/connection_spec.rb
@@ -370,20 +370,22 @@ describe PG::Connection do
 	end
 
 	it "times out after 2 * connect_timeout seconds on two connections" do
-		TCPServer.open( 'localhost', 54320 ) do |serv|
+		PG::TestingHelpers::ListenSocket.new do |sock|
 			start_time = Time.now
 			expect {
 				described_class.connect(
 					host: 'localhost,localhost',
-					port: 54320,
+					port: sock.port,
 					connect_timeout: 1,
 					dbname: "test")
 			}.to raise_error do |error|
 				expect( error ).to be_an( PG::ConnectionBad )
-				expect( error.message ).to match( /timeout expired.*timeout expired/m )
 				if PG.library_version >= 120000
+					expect( error.message ).to match( /timeout expired.*timeout expired/m )
 					expect( error.message ).to match( /\"localhost\".*\"localhost\"/m )
-					expect( error.message ).to match( /port 54320/ )
+					expect( error.message ).to match( /port #{sock.port}/ )
+				else
+					expect( error.message ).to match( /timeout expired/m )
 				end
 			end
 
@@ -392,11 +394,11 @@ describe PG::Connection do
 	end
 
 	it "succeeds with second host after connect_timeout" do
-		TCPServer.open( 'localhost', 54320 ) do |serv|
+		PG::TestingHelpers::ListenSocket.new do |sock|
 			start_time = Time.now
 			conn = described_class.connect(
 				host: 'localhost,localhost,localhost',
-				port: "54320,#{@port},54320",
+				port: "#{sock.port},#{@port},#{sock.port}",
 				connect_timeout: 1,
 				dbname: "test")
 
@@ -782,7 +784,8 @@ describe PG::Connection do
 	end
 
 	it "raises proper error when sending fails" do
-		conn = described_class.connect_start( '127.0.0.1', 54320, "", "", "me", "xxxx", "somedb" )
+		sock = PG::TestingHelpers::ListenSocket.new('127.0.0.1', accept: false){ }
+		conn = described_class.connect_start( '127.0.0.1', sock.port, "", "", "me", "xxxx", "somedb" )
 		expect{ conn.exec 'SELECT 1' }.to raise_error(PG::UnableToSend, /no connection/){|err| expect(err).to have_attributes(connection: conn) }
 	end
 
@@ -1688,11 +1691,12 @@ describe PG::Connection do
 
 
 	it "handles server close while asynchronous connect" do
-		serv = TCPServer.new( '127.0.0.1', 54320 )
-		conn = described_class.connect_start( '127.0.0.1', 54320, "", "", "me", "xxxx", "somedb" )
-		expect( [PG::PGRES_POLLING_WRITING, PG::CONNECTION_OK] ).to include conn.connect_poll
-		select( nil, [conn.socket_io], nil, 0.2 )
-		serv.close
+		conn = nil
+		PG::TestingHelpers::ListenSocket.new('127.0.0.1', accept: false) do |sock|
+			conn = described_class.connect_start( '127.0.0.1', sock.port, "", "", "me", "xxxx", "somedb" )
+			expect( [PG::PGRES_POLLING_WRITING, PG::CONNECTION_OK] ).to include conn.connect_poll
+			select( nil, [conn.socket_io], nil, 0.2 )
+		end
 		if conn.connect_poll == PG::PGRES_POLLING_READING
 			select( [conn.socket_io], nil, nil, 0.2 )
 		end
@@ -1816,12 +1820,13 @@ describe PG::Connection do
 	end
 
 	it "consume_input should raise ConnectionBad for a closed connection" do
-		serv = TCPServer.new( '127.0.0.1', 54320 )
-		conn = described_class.connect_start( '127.0.0.1', 54320, "", "", "me", "xxxx", "somedb" )
-		while [PG::CONNECTION_STARTED, PG::CONNECTION_MADE].include?(conn.connect_poll)
-			sleep 0.1
+		conn = nil
+		PG::TestingHelpers::ListenSocket.new '127.0.0.1', accept: false do |sock|
+			conn = described_class.connect_start( '127.0.0.1', sock.port, "", "", "me", "xxxx", "somedb" )
+			while [PG::CONNECTION_STARTED, PG::CONNECTION_MADE].include?(conn.connect_poll)
+				sleep 0.1
+			end
 		end
-		serv.close
 		expect{ conn.consume_input }.to raise_error(PG::ConnectionBad, /server closed the connection unexpectedly/){|err| expect(err).to have_attributes(connection: conn) }
 		expect{ conn.consume_input }.to raise_error(PG::ConnectionBad, /can't get socket descriptor|connection not open/){|err| expect(err).to have_attributes(connection: conn) }
 	end

--- a/spec/pg/connection_spec.rb
+++ b/spec/pg/connection_spec.rb
@@ -369,25 +369,25 @@ describe PG::Connection do
 		end
 	end
 
-	it "times out after connect_timeout seconds" do
+	it "times out after 2 * connect_timeout seconds on two connections" do
 		TCPServer.open( 'localhost', 54320 ) do |serv|
 			start_time = Time.now
 			expect {
 				described_class.connect(
-					host: 'localhost',
+					host: 'localhost,localhost',
 					port: 54320,
 					connect_timeout: 1,
 					dbname: "test")
 			}.to raise_error do |error|
 				expect( error ).to be_an( PG::ConnectionBad )
-				expect( error.message ).to match( /timeout expired/ )
+				expect( error.message ).to match( /timeout expired.*timeout expired/m )
 				if PG.library_version >= 120000
-					expect( error.message ).to match( /\"localhost\"/ )
+					expect( error.message ).to match( /\"localhost\".*\"localhost\"/m )
 					expect( error.message ).to match( /port 54320/ )
 				end
 			end
 
-			expect( Time.now - start_time ).to be_between(0.9, 10).inclusive
+			expect( Time.now - start_time ).to be_between(1.9, 10).inclusive
 		end
 	end
 


### PR DESCRIPTION
closes: #618 

libpq does not support connect_timeout when using the async api.

So when using the async connection API  with a multi-host connection string libpq will never timeout connections to the first host in the list and will not try try subsequent hosts in the connection string list.

This fixes this by closing and reopenning the connection with a reordered connection string if the connection to a host times out.

See discussion on the pgsql-hackers list discussing this "feature" of the api: https://www.postgresql.org/message-id/flat/CA%2Bmi_8YyGKA9dWELu63e%3DKL2oN-%2BFe4uca4EtFfb6uQD4Up8pw%40mail.gmail.com