### PR TITLE
Add possibility to define the number of array dimensions to be encoded

### DIFF
--- a/ext/pg.h
+++ b/ext/pg.h
@@ -206,6 +206,7 @@ typedef struct {
 	t_pg_coder comp;
 	t_pg_coder *elem;
 	int needs_quotation;
+	int dimensions;
 	char delimiter;
 } t_pg_composite_coder;
 

--- a/lib/pg/coder.rb
+++ b/lib/pg/coder.rb
@@ -76,12 +76,13 @@ module PG
 				elements_type: elements_type,
 				needs_quotation: needs_quotation?,
 				delimiter: delimiter,
+				dimensions: dimensions,
 			}
 		end
 
 		def inspect
 			str = super
-			str[-1,0] = " elements_type=#{elements_type.inspect} #{needs_quotation? ? 'needs' : 'no'} quotation"
+			str[-1,0] = " elements_type=#{elements_type.inspect} #{needs_quotation? ? 'needs' : 'no'} quotation#{dimensions && " #{dimensions} dimensions"}"
 			str
 		end
 	end


### PR DESCRIPTION
Setting dimensions is especially useful, when a Record shall be encoded into an Array, since the Array encoder can not distinguish if the array shall be encoded as a higher dimension or as a record otherwise.

Related to #620