### PR TITLE
Add cross compiler for aarch64-mingw-ucrt

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -44,6 +44,7 @@ end
 
 CrossLibrary = Struct.new :platform, :openssl_config, :toolchain
 CrossLibraries = [
+	['aarch64-mingw-ucrt', 'mingwarm64', 'aarch64-w64-mingw32'],
 	['x64-mingw-ucrt', 'mingw64', 'x86_64-w64-mingw32'],
 	['x86-mingw32', 'mingw', 'i686-w64-mingw32'],
 	['x64-mingw32', 'mingw64', 'x86_64-w64-mingw32'],

--- a/ext/extconf.rb
+++ b/ext/extconf.rb
@@ -126,12 +126,12 @@ if gem_platform=with_config("cross-build")
 			end
 		end
 
+		recipe.host = toolchain
 		recipe.configure_options << "CFLAGS=#{" -fPIC" if RUBY_PLATFORM =~ /linux/}"
-		recipe.configure_options << "LDFLAGS=-L#{openssl_recipe.path}/lib -L#{openssl_recipe.path}/lib64 #{"-Wl,-soname,libpq-ruby-pg.so.1 -lgssapi_krb5 -lkrb5 -lk5crypto -lkrb5support" if RUBY_PLATFORM =~ /linux/}"
+		recipe.configure_options << "LDFLAGS=-L#{openssl_recipe.path}/lib -L#{openssl_recipe.path}/lib64 -L#{openssl_recipe.path}/lib-arm64 #{"-Wl,-soname,libpq-ruby-pg.so.1 -lgssapi_krb5 -lkrb5 -lk5crypto -lkrb5support" if RUBY_PLATFORM =~ /linux/}"
 		recipe.configure_options << "LIBS=-lkrb5 -lcom_err -lk5crypto -lkrb5support -lresolv" if RUBY_PLATFORM =~ /linux/
 		recipe.configure_options << "LIBS=-lssl -lwsock32 -lgdi32 -lws2_32 -lcrypt32" if RUBY_PLATFORM =~ /mingw|mswin/
 		recipe.configure_options << "CPPFLAGS=-I#{openssl_recipe.path}/include"
-		recipe.host = toolchain
 		recipe.cook_and_activate
 	end
 
@@ -141,7 +141,7 @@ if gem_platform=with_config("cross-build")
 	# Avoid dependency to external libgcc.dll on x86-mingw32
 	$LDFLAGS << " -static-libgcc"
 	# Avoid: "libpq.so: undefined reference to `dlopen'" in cross-ruby-2.7.8
-	$LDFLAGS << " -Wl,--no-as-needed"
+	$LDFLAGS << " -Wl,--no-as-needed" if RUBY_PLATFORM !~ /aarch64/
 	# Find libpq in the ports directory coming from lib/3.3
 	# It is shared between all compiled ruby versions.
 	$LDFLAGS << " '-Wl,-rpath=$$ORIGIN/../../ports/#{gem_platform}/lib'"

--- a/ports/patches/openssl/3.4.0/0001-aarch64-mingw.patch
+++ b/ports/patches/openssl/3.4.0/0001-aarch64-mingw.patch
@@ -1,0 +1,21 @@
+--- a/Configurations/10-main.conf
++++ b/Configurations/10-main.conf
+@@ -1603,6 +1603,18 @@
+         multilib         => "64",
+     },
+ 
++    "mingwarm64" => {
++        inherit_from     => [ "mingw-common" ],
++        cflags           => "",
++        sys_id           => "MINGWARM64",
++        bn_ops           => add("SIXTY_FOUR_BIT"),
++        asm_arch         => 'aarch64',
++        uplink_arch      => 'armv8',
++        perlasm_scheme   => "win64",
++        shared_rcflag    => "",
++        multilib         => "-arm64",
++    },
++
+ #### UEFI
+     "UEFI" => {
+         inherit_from     => [ "BASE_unix" ],

--- a/ports/patches/postgresql/17.2/0001-Use-workaround-of-__builtin_setjmp-only-on-MINGW-on-.patch
+++ b/ports/patches/postgresql/17.2/0001-Use-workaround-of-__builtin_setjmp-only-on-MINGW-on-.patch
@@ -1,0 +1,42 @@
+From 746e8e250b265c40d9706f26560e02e8623f123f Mon Sep 17 00:00:00 2001
+From: Lars Kanis <lars@greiz-reinsdorf.de>
+Date: Fri, 31 Jan 2025 21:58:00 +0100
+Subject: [PATCH] Use workaround of __builtin_setjmp only on MINGW on MSVCRT
+
+Because it is not present on ARM64 on Windows and not necessary on any UCRT based toolchain.
+---
+ src/include/c.h | 10 +++++-----
+ 1 file changed, 5 insertions(+), 5 deletions(-)
+
+diff --git a/src/include/c.h b/src/include/c.h
+index a14c631516..33792c860c 100644
+--- a/src/include/c.h
++++ b/src/include/c.h
+@@ -1312,19 +1312,19 @@ extern int	fdatasync(int fildes);
+ /*
+  * When there is no sigsetjmp, its functionality is provided by plain
+  * setjmp.  We now support the case only on Windows.  However, it seems
+- * that MinGW-64 has some longstanding issues in its setjmp support,
+- * so on that toolchain we cheat and use gcc's builtins.
++ * that MinGW-64 on x86_64 has some longstanding issues in its setjmp
++ * support, so on that toolchain we cheat and use gcc's builtins.
+  */
+ #ifdef WIN32
+-#ifdef __MINGW64__
++#if defined(__MINGW64__) && !defined(_UCRT)
+ typedef intptr_t sigjmp_buf[5];
+ #define sigsetjmp(x,y) __builtin_setjmp(x)
+ #define siglongjmp __builtin_longjmp
+-#else							/* !__MINGW64__ */
++#else							/* !defined(__MINGW64__) || defined(_UCRT) */
+ #define sigjmp_buf jmp_buf
+ #define sigsetjmp(x,y) setjmp(x)
+ #define siglongjmp longjmp
+-#endif							/* __MINGW64__ */
++#endif							/* defined(__MINGW64__) && !defined(_UCRT) */
+ #endif							/* WIN32 */
+ 
+ /* /port compatibility functions */
+-- 
+2.43.0
+


### PR DESCRIPTION
This adds rake target `rake gem:native:aarch64-mingw-ucrt`.

It needs rake-compiler-dock with support for Windows on Arm64, introduced in: https://github.com/rake-compiler/rake-compiler-dock/pull/152

Patches submitted:
* Postgresql: https://commitfest.postgresql.org/patch/5610/
* OpenSSL: https://github.com/openssl/openssl/pull/26605