### PR TITLE
Use a connection encoding compatible to "Möhre"

### DIFF
--- a/spec/pg/connection_spec.rb
+++ b/spec/pg/connection_spec.rb
@@ -2325,7 +2325,7 @@ describe PG::Connection do
 
 			it "uses the previous string encoding for escaped string" do
 				original = "Möhre to 'scape".encode( "iso-8859-1" )
-				@conn.set_client_encoding( "euc_jp" )
+				@conn.set_client_encoding( "iso-8859-2" )
 				escaped  = described_class.escape( original )
 				expect( escaped.encoding ).to eq( Encoding::ISO8859_1 )
 				expect( escaped ).to eq( "Möhre to ''scape".encode(Encoding::ISO8859_1) )


### PR DESCRIPTION
The function `PQescapeString` was changed in PostgreSQL 17.4, 16.8, 15.12, 14.17, and 13.20. It now returns a predefined invalid character as a replacement in the connection encoding, if the input text is not valid according to the current connection encoding. Using a compatible connection encoding avoids this, so that we get the original text out of the singleton escape function.

Fixes #628