### PR TITLE
Avoid usage of port 54321 for tests but use 23456

### DIFF
--- a/spec/helpers.rb
+++ b/spec/helpers.rb
@@ -250,7 +250,7 @@ module PG::TestingHelpers
 		attr_reader :pgdata
 
 		### Set up a PostgreSQL database instance for testing.
-		def initialize( name, port: 54321, postgresql_conf: '' )
+		def initialize( name, port: 23456, postgresql_conf: '' )
 			trace "Setting up test database for #{name}"
 			@name = name
 			@port = port
@@ -719,7 +719,7 @@ RSpec.configure do |config|
 		PG::TestingHelpers.stop_existing_postmasters
 
 		ENV['PGHOST'] = 'localhost'
-		ENV['PGPORT'] ||= "54321"
+		ENV['PGPORT'] ||= "23456"
 		port = ENV['PGPORT'].to_i
 		$pg_server = PG::TestingHelpers::PostgresServer.new("specs", port: port)
 		$pg_server.create_test_db

--- a/spec/pg/connection_spec.rb
+++ b/spec/pg/connection_spec.rb
@@ -1527,7 +1527,7 @@ describe PG::Connection do
 	it "can return the default connection options as a Hash" do
 		expect( described_class.conndefaults_hash ).to be_a( Hash )
 		expect( described_class.conndefaults_hash ).to include( :user, :password, :dbname, :host, :port )
-		expect( ['5432', '54321', @port.to_s] ).to include( described_class.conndefaults_hash[:port] )
+		expect( ['5432', '23456', @port.to_s] ).to include( described_class.conndefaults_hash[:port] )
 		expect( @conn.conndefaults_hash ).to eq( described_class.conndefaults_hash )
 	end
 


### PR DESCRIPTION
54321 is an ephemeral port on most operating systems, so that is's sometimes already in use in CI. This makes initdb fail sometimes on Windows like so:

```
Success. You can now start the database server using:

    "D:\a\ruby-pg\ruby-pg\pgsql\bin\pg_ctl" -D D:/a/ruby-pg/ruby-pg/tmp_test_specs/data -l logfile start

waiting for server to start....2025-03-09 16:03:40.843 UTC [4624] LOG:  starting PostgreSQL 17.0 on x86_64-windows, compiled by msvc-19.41.34120, 64-bit
2025-03-09 16:03:40.846 UTC [4624] LOG:  could not bind IPv6 address "::1": Permission denied
2025-03-09 16:03:40.846 UTC [4624] LOG:  could not bind IPv4 address "127.0.0.1": Permission denied
2025-03-09 16:03:40.846 UTC [4624] WARNING:  could not create listen socket for "localhost"
2025-03-09 16:03:40.846 UTC [4624] FATAL:  could not create any TCP/IP sockets
2025-03-09 16:03:40.847 UTC [4624] LOG:  database system is shut down
```