### PR TITLE
Fix making PG::BasicTypeMapForQueries shareable for Ractor

### DIFF
--- a/lib/pg/basic_type_map_for_queries.rb
+++ b/lib/pg/basic_type_map_for_queries.rb
@@ -53,13 +53,17 @@ class PG::BasicTypeMapForQueries < PG::TypeMapByClass
 		@coder_maps = build_coder_maps(connection_or_coder_maps, registry: registry)
 		@array_encoders_by_klass = array_encoders_by_klass
 		@encode_array_as = :array
-		@if_undefined = if_undefined || method(:raise_undefined_type).to_proc
+		@if_undefined = if_undefined || UndefinedDefault
 		init_encoders
 	end
 
-	private def raise_undefined_type(oid_name, format)
-		raise UndefinedEncoder, "no encoder defined for type #{oid_name.inspect} format #{format}"
+	class UndefinedDefault
+		def self.call(oid_name, format)
+			raise UndefinedEncoder, "no encoder defined for type #{oid_name.inspect} format #{format}"
+		end
 	end
+
+	private_constant :UndefinedDefault
 
 	# Change the mechanism that is used to encode ruby array values
 	#


### PR DESCRIPTION
This was broken since ruby commit https://github.com/ruby/ruby/commit/d80f3a287c5c8d0404b6cb837db360cab320cde1 .
It shrinked shareability of `Proc` objects, so that we need to avoid a `Proc` here.