### PR TITLE
Remove installation of Macos "mig" tool

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -104,19 +104,6 @@ task 'gem:native:prepare' do
 	end
 end
 
-task 'install_darwin_mig', [:arch] do |t, args|
-	sh <<~EOT
-		rm -rf bootstrap_cmds &&
-		git clone --branch=cross_platform https://github.com/markmentovai/bootstrap_cmds &&
-		cd bootstrap_cmds &&
-		autoreconf --install &&
-		sh configure &&
-		make &&
-		sed -E -i 's/^cppflags=(.*)/cppflags=(\\1 "-D#{args[:arch]}" "-I\\/opt\\/osxcross\\/target\\/SDK\\/MacOSX11.1.sdk\\/usr\\/include")/' migcom.tproj/mig.sh &&
-		sudo make install
-	EOT
-end
-
 CrossLibraries.each do |xlib|
 	platform = xlib.platform
 	desc "Build fat binary gem for platform #{platform}"
@@ -128,8 +115,6 @@ CrossLibraries.each do |xlib|
 			sudo apt-get update && sudo apt-get install -y bison flex &&
 			(cp build/gem/gem-*.pem ~/.gem/ || true) &&
 			bundle install --local &&
-			#{ "rake install_darwin_mig[__arm64__]" if platform =~ /arm64-darwin/ }
-			#{ "rake install_darwin_mig[__x86_64__]" if platform =~ /x86_64-darwin/ }
 			rake native:#{platform} pkg/#{$gem_spec.full_name}-#{platform}.gem MAKEOPTS=-j`nproc` RUBY_CC_VERSION=#{RakeCompilerDock.ruby_cc_version("~>2.7", "~>3.0")}
 		EOT
 	end


### PR DESCRIPTION
It was added to rake-compiler-dock in https://github.com/rake-compiler/rake-compiler-dock/pull/155 .

This PR can be merged when rake-compiler-dock.1.10 is released and updated in pg's Gemfile.