### PR TITLE
CI: Remove ruby < 3.2 from test matrix on Windows

### DIFF
--- a/.github/workflows/binary-gems.yml
+++ b/.github/workflows/binary-gems.yml
@@ -63,15 +63,15 @@ jobs:
       matrix:
         include:
           - os: windows-latest
-            ruby: "3.3"
+            ruby: "3.4"
             platform: "x64-mingw-ucrt"
           - os: windows-latest
-            ruby: "3.1.4-1"
+            ruby: "3.2.9-1"
             platform: "x86-mingw32"
             PGVERSION: 10.20-1-windows
           - os: windows-latest
-            ruby: "2.7"
-            platform: "x64-mingw32"
+            ruby: "3.2"
+            platform: "x64-mingw-ucrt"
             PGVERSION: 16.6-1-windows-x64
           - os: ubuntu-latest
             ruby: "3.2"
@@ -116,7 +116,10 @@ jobs:
         with:
           name: binary-gem-${{ matrix.platform }}
 
-      - name: Download PostgreSQL 32-bit
+      - run: bundle install
+      - run: gem install --local pg-*${{ matrix.platform }}.gem --verbose
+
+      - name: Download PostgreSQL
         if: ${{ matrix.os == 'windows-latest' && matrix.PGVERSION }}
         run: |
           Add-Type -AssemblyName System.IO.Compression.FileSystem
@@ -135,9 +138,6 @@ jobs:
           echo "PGPASSWORD="  | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
 
       - run: echo $env:PATH
-      - run: gem update --system 3.3.26
-      - run: bundle install
-      - run: gem install --local pg-*${{ matrix.platform }}.gem --verbose
       - name: Run specs
         if: ${{ matrix.os != 'windows-latest' }}
         run: ruby -rpg -S rspec -fd spec/**/*_spec.rb

--- a/.github/workflows/source-gem.yml
+++ b/.github/workflows/source-gem.yml
@@ -47,7 +47,7 @@ jobs:
             PGVERSION: 17.0-1-windows-x64
             PGVER: "17"
           - os: windows
-            ruby: "2.7"
+            ruby: "3.2"
             PGVERSION: 10.20-1-windows-x64
             PGVER: "10"
           - os: windows
@@ -88,6 +88,12 @@ jobs:
         with:
           ruby-version: ${{ matrix.ruby }}
 
+      - name: Print tool versions
+        run: |
+          ruby -v
+          gem env
+          gcc -v
+
       - name: Download gem from build job
         uses: actions/download-artifact@v4
         with:
@@ -97,6 +103,8 @@ jobs:
         if: matrix.os == 'windows' && matrix.ruby != 'mswin'
         shell: cmd
         run: ridk exec sh -c "pacman --sync --needed --noconfirm  ${MINGW_PACKAGE_PREFIX}-gcc"
+
+      - run: bundle install
 
       - name: Download PostgreSQL Windows
         if: matrix.os == 'windows'
@@ -109,7 +117,7 @@ jobs:
 
           $(new-object net.webclient).DownloadFile("http://get.enterprisedb.com/postgresql/postgresql-$env:PGVERSION-binaries.zip", "postgresql-binaries.zip")
           Unzip "postgresql-binaries.zip" "."
-          echo "$pwd/pgsql/bin"  | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+          echo "$env:RI_DEVKIT$env:MINGW_PREFIX/bin;$env:RI_DEVKIT/usr/bin;$pwd/pgsql/bin"  | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
           echo "PGUSER=$env:USERNAME"  | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
           echo "PGPASSWORD="  | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
 
@@ -131,9 +139,7 @@ jobs:
           sudo mv /Library/PostgreSQL/$PGVER/pgsql/* /Library/PostgreSQL/$PGVER/ && \
           echo /Library/PostgreSQL/$PGVER/bin >> $GITHUB_PATH
 
-      - run: gem update --system 3.3.26
-      - run: bundle install
-
+      - run: echo $env:PATH
       - run: gem install --local *.gem --verbose
 
       - name: Run specs
@@ -143,10 +149,16 @@ jobs:
           TRUFFLERUBYOPT: --experimental-options --keep-handles-alive
         run: ruby -rpg -S rspec spec/**/*_spec.rb -cfdoc
 
-      - name: Print logs if job failed
+      - name: Print db logs if job failed
         if: ${{ failure() && matrix.os == 'windows' }}
         run: ridk exec cat tmp_test_specs/*.log
 
-      - name: Print logs if job failed
+      - name: Print db logs if job failed
         if: ${{ failure() && matrix.os != 'windows' }}
         run: cat tmp_test_specs/*.log
+
+      - name: Print mkmf logs if job failed on Windows-head
+        if: ${{ failure() && matrix.os == 'windows' && matrix.ruby == 'head' }}
+        run: |
+          ridk exec cat c:/rubyinstaller-head-*/lib/ruby/gems/*/extensions/*/*/*/mkmf.log || ridk exec cat d:/rubyinstaller-head-*/lib/ruby/gems/*/extensions/*/*/*/mkmf.log
+          ridk exec gcc -v


### PR DESCRIPTION
Ruby < 3.2 is not compatible to gcc-15 and patches will not be backported since it's EOL now. Unfortunately MSYS2 is a rolling release with no option for an older gcc. Althought setup-ruby installs an older gcc-14.2 package by default, it fails to install further packages per pacman due to dependencies:

```sh
  $ pacman.exe -Sy --noconfirm --noprogressbar --needed --disable-download-timeout  mingw-w64-x86_64-postgresql
  resolving dependencies...
  looking for conflicting packages...
  error: failed to prepare transaction (could not satisfy dependencies)
  :: installing mingw-w64-x86_64-gcc-libs (15.1.0-8) breaks dependency 'mingw-w64-x86_64-gcc-libs=14.2.0-3' required by mingw-w64-x86_64-gcc
```