### PR TITLE
Serialize CompositeCoder#dimensions only when set

### DIFF
--- a/lib/pg/coder.rb
+++ b/lib/pg/coder.rb
@@ -72,12 +72,13 @@ module PG
 
 	class CompositeCoder < Coder
 		def to_h
-			{ **super,
+			h = { **super,
 				elements_type: elements_type,
 				needs_quotation: needs_quotation?,
 				delimiter: delimiter,
-				dimensions: dimensions,
 			}
+			h[:dimensions] = dimensions if dimensions # Write only when set, for Marshal compat with pg<1.6
+			h
 		end
 
 		def inspect

--- a/spec/pg/type_spec.rb
+++ b/spec/pg/type_spec.rb
@@ -1184,8 +1184,15 @@ describe "PG::Type derivations" do
 			it "should respond to to_h" do
 				expect( textenc_int_array.to_h ).to eq( {
 					name: nil, oid: 0, format: 0, flags: 0,
-					elements_type: textenc_int, needs_quotation: false, delimiter: ',',
-					dimensions: nil
+					elements_type: textenc_int, needs_quotation: false, delimiter: ','
+				} )
+			end
+
+			it "should respond to to_h with dimensions set" do
+				enc_array = PG::BinaryEncoder::Array.new dimensions: 1
+				expect( enc_array.to_h ).to eq( {
+					name: nil, oid: 0, format: 1, flags: 0, dimensions: 1,
+					elements_type: nil, needs_quotation: true, delimiter: ','
 				} )
 			end
 


### PR DESCRIPTION
This fixes the compatibility to pg-1.5.9, when deserializing Marshal data from pg-1.6, as long as the new attribute isn't used.

Fixes #652