### PR TITLE
Fix use of `kernel.open` or `IO.read` or similar sinks with a non-constant value

### DIFF
--- a/spec/helpers.rb
+++ b/spec/helpers.rb
@@ -474,7 +474,7 @@ EOT
 
 			csr_cert.sign ca_key, OpenSSL::Digest::SHA256.new
 
-			open "#{output_dir}/#{name}", 'w' do |io|
+			File.open "#{output_dir}/#{name}", 'w' do |io|
 				io.puts csr_cert.to_text
 				io.write csr_cert.to_pem
 			end


### PR DESCRIPTION
https://github.com/ged/ruby-pg/blob/dae9173a10a194c6bfd1a5eb6bcb98637cfbf4b5/spec/helpers.rb#L477-L480
Call to Kernel.open with a non-constant value. Consider replacing it with File.open. If Kernel.open is given a file name that starts with a | character, it will execute the remaining string as a shell command. If a malicious user can control the file name, they can execute arbitrary code. The same vulnerability applies to IO.read, IO.write, IO.binread, IO.binwrite, IO.foreach, IO.readlines and URI.open.


fix the problem, replace the call to `open` on line 477 with `File.open`. This change ensures that the file is opened for writing without the risk of command injection, as `File.open` does not interpret file names starting with `|` as shell commands. No additional imports or changes are needed, as `File` is part of Ruby's core library. The change should be made only to the affected line, preserving the rest of the logic and block structure.


#### References
[Command Injection](https://www.owasp.org/index.php/Command_Injection). [Ruby on Rails Cheat Sheet: Command Injection](https://cheatsheetseries.owasp.org/cheatsheets/Ruby_on_Rails_Cheat_Sheet.html#command-injection)
[Command Injection in RDoc](https://www.ruby-lang.org/en/news/2021/05/02/os-command-injection-in-rdoc/)