### PR TITLE
Use "rbpg_" prefix for base64_* functions

### DIFF
--- a/ext/pg_binary_decoder.c
+++ b/ext/pg_binary_decoder.c
@@ -117,7 +117,7 @@ pg_bin_dec_to_base64(t_pg_coder *conv, const char *val, int len, int tuple, int 
 	/* create a buffer of the encoded length */
 	VALUE out_value = rb_str_new(NULL, encoded_len);
 
-	base64_encode( RSTRING_PTR(out_value), val, len );
+	rbpg_base64_encode( RSTRING_PTR(out_value), val, len );
 
 	/* Is it a pure String conversion? Then we can directly send out_value to the user. */
 	if( this->comp.format == 0 && dec_func == pg_text_dec_string ){

--- a/ext/pg_binary_encoder.c
+++ b/ext/pg_binary_encoder.c
@@ -524,7 +524,7 @@ pg_bin_enc_from_base64(t_pg_coder *conv, VALUE value, char *out, VALUE *intermed
 	if(out){
 		/* Second encoder pass, if required */
 		strlen = enc_func(this->elem, value, out, intermediate, enc_idx);
-		strlen = base64_decode( out, out, strlen );
+		strlen = rbpg_base64_decode( out, out, strlen );
 
 		return strlen;
 	} else {
@@ -538,7 +538,7 @@ pg_bin_enc_from_base64(t_pg_coder *conv, VALUE value, char *out, VALUE *intermed
 			strlen = RSTRING_LENINT(subint);
 			out_str = rb_str_new(NULL, BASE64_DECODED_SIZE(strlen));
 
-			strlen = base64_decode( RSTRING_PTR(out_str), RSTRING_PTR(subint), strlen);
+			strlen = rbpg_base64_decode( RSTRING_PTR(out_str), RSTRING_PTR(subint), strlen);
 			rb_str_set_len( out_str, strlen );
 			*intermediate = out_str;
 

--- a/ext/pg_text_decoder.c
+++ b/ext/pg_text_decoder.c
@@ -579,7 +579,7 @@ pg_text_dec_from_base64(t_pg_coder *conv, const char *val, int len, int tuple, i
 	/* create a buffer of the expected decoded length */
 	VALUE out_value = rb_str_new(NULL, BASE64_DECODED_SIZE(len));
 
-	decoded_len = base64_decode( RSTRING_PTR(out_value), val, len );
+	decoded_len = rbpg_base64_decode( RSTRING_PTR(out_value), val, len );
 	rb_str_set_len(out_value, decoded_len);
 
 	/* Is it a pure String conversion? Then we can directly send out_value to the user. */

--- a/ext/pg_text_encoder.c
+++ b/ext/pg_text_encoder.c
@@ -784,7 +784,7 @@ pg_text_enc_to_base64(t_pg_coder *conv, VALUE value, char *out, VALUE *intermedi
 	if(out){
 		/* Second encoder pass, if required */
 		strlen = enc_func(this->elem, value, out, intermediate, enc_idx);
-		base64_encode( out, out, strlen );
+		rbpg_base64_encode( out, out, strlen );
 
 		return BASE64_ENCODED_SIZE(strlen);
 	} else {
@@ -799,7 +799,7 @@ pg_text_enc_to_base64(t_pg_coder *conv, VALUE value, char *out, VALUE *intermedi
 			out_str = rb_str_new(NULL, BASE64_ENCODED_SIZE(strlen));
 			PG_ENCODING_SET_NOCHECK(out_str, enc_idx);
 
-			base64_encode( RSTRING_PTR(out_str), RSTRING_PTR(subint), strlen);
+			rbpg_base64_encode( RSTRING_PTR(out_str), RSTRING_PTR(subint), strlen);
 			*intermediate = out_str;
 
 			return -1;

--- a/ext/pg_util.c
+++ b/ext/pg_util.c
@@ -15,7 +15,7 @@ static const char base64_encode_table[] = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijk
  * in-place (with _out_ == _in_).
  */
 void
-base64_encode( char *out, const char *in, int len)
+rbpg_base64_encode( char *out, const char *in, int len)
 {
 	const unsigned char *in_ptr = (const unsigned char *)in + len;
 	char *out_ptr = out + BASE64_ENCODED_SIZE(len);
@@ -72,7 +72,7 @@ static const unsigned char base64_decode_table[] =
  * It is possible to decode a string in-place (with _out_ == _in_).
  */
 int
-base64_decode( char *out, const char *in, unsigned int len)
+rbpg_base64_decode( char *out, const char *in, unsigned int len)
 {
 	unsigned char a, b, c, d;
 	const unsigned char *in_ptr = (const unsigned char *)in;

--- a/ext/pg_util.h
+++ b/ext/pg_util.h
@@ -57,8 +57,8 @@
 #define BASE64_ENCODED_SIZE(strlen) (((strlen) + 2) / 3 * 4)
 #define BASE64_DECODED_SIZE(base64len) (((base64len) + 3) / 4 * 3)
 
-void base64_encode( char *out, const char *in, int len);
-int base64_decode( char *out, const char *in, unsigned int len);
+void rbpg_base64_encode( char *out, const char *in, int len);
+int rbpg_base64_decode( char *out, const char *in, unsigned int len);
 
 int rbpg_strncasecmp(const char *s1, const char *s2, size_t n);
 


### PR DESCRIPTION
To avoid name clashes with functions provided by other libraries like Heimdal.

Otherwise this fails with a segfault on Macos due to this function:
  `/System/Library/PrivateFrameworks/Heimdal.framework/Versions/A/Heimdal(base64_encode+0x94)`