### PR TITLE
Remove absolute paths from binaries which point to build directories

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -141,7 +141,7 @@ CrossLibraries.each do |xlib|
 			bundle install --local &&
 			#{ "rake install_darwin_mig[__arm64__]" if platform =~ /arm64-darwin/ }
 			#{ "rake install_darwin_mig[__x86_64__]" if platform =~ /x86_64-darwin/ }
-			rake native:#{platform} pkg/#{$gem_spec.full_name}-#{platform}.gem MAKEOPTS=-j`nproc` RUBY_CC_VERSION=#{RakeCompilerDock.ruby_cc_version("~>2.7", "~>3.0")}
+			rake native:#{platform} pkg/#{$gem_spec.full_name}-#{platform}.gem MAKEFLAGS="-j`nproc` V=1" RUBY_CC_VERSION=#{RakeCompilerDock.ruby_cc_version("~>2.7", "~>3.0")}
 		EOT
 	end
 	desc "Build the native binary gems"


### PR DESCRIPTION
There are several absolute paths built into the binary. For instance fallback path to `pg_service.conf` or the fallback path to kerberos ccache file or the rpath included into the libpq or C-ext files.

They can be avoided or fixed by disabling rpaths and by using `DESTDIR` instead of `--prefix` configure option.

Fixes #666

The remaining rpath to libruby will probably be fixed by: https://github.com/rake-compiler/rake-compiler-dock/pull/165

Also fix the `MAKEFLAGS` option. `MAKEOPTS` was wrong.