### PR TITLE
PG::Result: Initialize all on-demand values before freeze

### DIFF
--- a/ext/extconf.rb
+++ b/ext/extconf.rb
@@ -319,6 +319,7 @@ have_func 'PQsetChunkedRowsMode', 'libpq-fe.h' # since PostgreSQL-17
 have_func 'timegm'
 have_func 'rb_io_wait' # since ruby-3.0
 have_func 'rb_io_descriptor' # since ruby-3.1
+have_func 'rb_hash_new_capa' # since ruby-3.2
 
 have_header 'inttypes.h'
 have_header('ruby/fiber/scheduler.h') if RUBY_PLATFORM=~/mingw|mswin/

--- a/ext/pg.h
+++ b/ext/pg.h
@@ -157,10 +157,12 @@ typedef struct {
 	/* Size of PGresult as published to ruby memory management. */
 	ssize_t result_size;
 
-	/* Prefilled tuple Hash with fnames[] as keys. */
+	/* Prefilled tuple Hash with fnames[] as keys.
+	 * Only used in pgresult_aref() with more than 10 rows, otherwise Qnil. */
 	VALUE tuple_hash;
 
-	/* Hash with fnames[] to field number mapping. */
+	/* Hash with fnames[] to field number mapping.
+	 * Init on-demand to create PG::Tuple objects, otherwise Qnil. */
 	VALUE field_map;
 
 	/* List of field names as frozen String or Symbol objects.

--- a/ext/pg.h
+++ b/ext/pg.h
@@ -76,6 +76,10 @@ typedef long suseconds_t;
 	#define PG_MAX_COLUMNS 4000
 #endif
 
+#ifndef HAVE_RB_HASH_NEW_CAPA
+#define rb_hash_new_capa(x) rb_hash_new()
+#endif
+
 #define pg_gc_location(x) x = rb_gc_location(x)
 
 /* For compatibility with ruby < 3.0 */

--- a/ext/pg.h
+++ b/ext/pg.h
@@ -157,10 +157,6 @@ typedef struct {
 	/* Size of PGresult as published to ruby memory management. */
 	ssize_t result_size;
 
-	/* Prefilled tuple Hash with fnames[] as keys.
-	 * Only used in pgresult_aref() with more than 10 rows, otherwise Qnil. */
-	VALUE tuple_hash;
-
 	/* Hash with fnames[] to field number mapping.
 	 * Init on-demand to create PG::Tuple objects, otherwise Qnil. */
 	VALUE field_map;

--- a/ext/pg_connection.c
+++ b/ext/pg_connection.c
@@ -2382,7 +2382,7 @@ pgconn_notifies(VALUE self)
 		return Qnil;
 	}
 
-	hash = rb_hash_new();
+	hash = rb_hash_new_capa(3);
 	relname = rb_str_new2(notification->relname);
 	be_pid = INT2NUM(notification->be_pid);
 	extra = rb_str_new2(notification->extra);

--- a/ext/pg_result.c
+++ b/ext/pg_result.c
@@ -1363,11 +1363,12 @@ static void ensure_init_for_tuple(VALUE self)
 
 	if( this->field_map == Qnil ){
 		int i;
-		VALUE field_map = rb_hash_new();
+		VALUE field_map;
 
 		if( this->nfields == -1 )
 			pgresult_init_fnames( self );
 
+		field_map = rb_hash_new_capa(this->nfields);
 		for( i = 0; i < this->nfields; i++ ){
 			rb_hash_aset(field_map, this->fnames[i], INT2FIX(i));
 		}

--- a/ext/pg_result.c
+++ b/ext/pg_result.c
@@ -12,6 +12,7 @@ static VALUE sym_symbol, sym_string, sym_static_symbol;
 static VALUE pgresult_type_map_set( VALUE, VALUE );
 static t_pg_result *pgresult_get_this( VALUE );
 static t_pg_result *pgresult_get_this_safe( VALUE );
+static void ensure_init_for_tuple(VALUE self);
 
 #if defined(HAVE_PQRESULTMEMORYSIZE)
 
@@ -396,6 +397,8 @@ pg_result_freeze(VALUE self)
 {
 	t_pg_result *this = pgresult_get_this(self);
 
+	ensure_init_for_tuple(self);
+	RB_OBJ_WRITE(self, &this->tuple_hash, Qnil);
 	RB_OBJ_WRITE(self, &this->connection, Qnil);
 	return rb_call_super(0, NULL);
 }
@@ -1184,7 +1187,7 @@ pgresult_aref(VALUE self, VALUE index)
 		rb_hash_aset( tuple, this->fnames[field_num], val );
 	}
 	/* Store a copy of the filled hash for use at the next row. */
-	if( num_tuples > 10 )
+	if( num_tuples > 10 && !RB_OBJ_FROZEN(self))
 		RB_OBJ_WRITE(self, &this->tuple_hash, rb_hash_dup(tuple));
 
 	return tuple;

--- a/ext/pg_tuple.c
+++ b/ext/pg_tuple.c
@@ -510,7 +510,7 @@ pg_tuple_load(VALUE self, VALUE a)
 	if (RARRAY_LENINT(field_names) != num_fields)
 		rb_raise(rb_eTypeError, "different number of fields and values");
 
-	field_map = rb_hash_new();
+	field_map = rb_hash_new_capa(num_fields);
 	for( i = 0; i < num_fields; i++ ){
 		rb_hash_aset(field_map, RARRAY_AREF(field_names, i), INT2FIX(i));
 	}


### PR DESCRIPTION
Multiple Ractor instances could otherwise initialize them simultanly, leading to data races.