### PR TITLE
Prohibit communication on frozen connections

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,8 +221,8 @@ Several type maps can be chained by setting PG::TypeMap::DefaultTypeMappable#def
 
 ## Thread support
 
-PG is thread safe in such a way that different threads can use different PG::Connection objects concurrently.
-However it is not safe to access any Pg objects simultaneously from more than one thread.
+PG is thread safe in such a way that different threads or fibers can use different PG::Connection objects concurrently.
+However it is not safe to access any PG object simultaneously from more than one thread or fiber unless the object is frozen.
 So make sure to open a new database server connection for every new thread or use a wrapper library like ActiveRecord that manages connections in a thread safe way.
 
 If messages like the following are printed to stderr, you're probably using one connection from several threads:

--- a/ext/pg_connection.c
+++ b/ext/pg_connection.c
@@ -66,6 +66,7 @@ pg_get_connection_safe( VALUE self )
 	t_pg_connection *this;
 	TypedData_Get_Struct( self, t_pg_connection, &pg_connection_type, this);
 
+	rb_check_frozen(self);
 	if ( !this->pgconn )
 		pg_raise_conn_error( rb_eConnectionBad, self, "connection is closed");
 

--- a/spec/pg/connection_spec.rb
+++ b/spec/pg/connection_spec.rb
@@ -23,8 +23,11 @@ describe PG::Connection do
 		expect{ c.field_name_type = :symbol  }.to raise_error(FrozenError)
 		expect{ c.set_default_encoding }.to raise_error(FrozenError)
 		expect{ c.internal_encoding = nil }.to raise_error(FrozenError)
-	ensure
-		c&.finish
+		expect{ c.exec("") }.to raise_error(FrozenError)
+		expect{ c.send_query("") }.to raise_error(FrozenError)
+		expect{ c.exec_prepared("a") }.to raise_error(FrozenError)
+		expect{ c.finish }.to raise_error(FrozenError)
+		expect( c.finished? ).to be_falsey
 	end
 
 	it "shouldn't be shareable for Ractor", :ractor do


### PR DESCRIPTION
Similar to ruby IO objects, this denies communication with the server when the PG::Connection is frozen. Mention this fact in the README and that concurrent use is also disallowed in multiple fibers, not only multiple threads.