### PR TITLE
Remove enforced rpath addition when no rpath is configured

### DIFF
--- a/ext/extconf.rb
+++ b/ext/extconf.rb
@@ -218,13 +218,6 @@ else
 		dlldir = libdir
 	end
 
-	# Try to use runtime path linker option, even if RbConfig doesn't know about it.
-	# The rpath option is usually set implicit by dir_config(), but so far not
-	# on MacOS-X.
-	if dlldir && RbConfig::CONFIG["RPATHFLAG"].to_s.empty?
-		append_ldflags "-Wl,-rpath,#{dlldir.quote}"
-	end
-
 	if /mswin/ =~ RUBY_PLATFORM
 		$libs = append_library($libs, 'ws2_32')
 	end


### PR DESCRIPTION
That code was introduced 13 years ago.
I think it can be removed now, since this was an issue in an old ruby version. If the rpath is configured in ruby, then dir_config will use it, otherwise it shouldn't.

If ruby is configured with
```
   ./configure --disable-rpath
```

then pg shouldn't use the `rpath` either.

Fixes #183