### PR TITLE
Add support for lambda or Proc :password key in connection Hash

### DIFF
--- a/lib/pg/connection.rb
+++ b/lib/pg/connection.rb
@@ -58,11 +58,15 @@ class PG::Connection
 	# * URI string
 	# * URI object
 	# * positional arguments
+  #
+  # If an option Hash is used, :password can be a Proc or lambda that returns a
+  # string, so as to support dynamic passwords.
 	#
 	# The method adds the option "fallback_application_name" if it isn't already set.
 	# It returns a connection string with "key=value" pairs.
 	def self.parse_connect_args( *args )
 		hash_arg = args.last.is_a?( Hash ) ? args.pop.transform_keys(&:to_sym) : {}
+		hash_arg[:password] = hash_arg[:password].call if hash_arg[:password].respond_to?(:call)
 		iopts = {}
 
 		if args.length == 1

--- a/spec/pg/connection_spec.rb
+++ b/spec/pg/connection_spec.rb
@@ -313,6 +313,28 @@ describe PG::Connection do
 				PG::Connection.class_eval("PROGRAM_NAME=PG.make_shareable(#{old_script_name.inspect})")
 			end
 		end
+
+		it "accepts a lambda as the :password key of a Hash parameter" do
+			optstring = described_class.parse_connect_args(
+				:dbname => 'db01',
+				:password => lambda { 'password_via_lambda' }
+				)
+
+			expect( optstring ).to be_a( String )
+			expect( optstring ).to match( /(^|\s)dbname='db01'/ )
+			expect( optstring ).to match( /(^|\s)password='password_via_lambda'/ )
+		end
+
+		it "accepts a Proc as the :password key of a Hash parameter" do
+			optstring = described_class.parse_connect_args(
+				:dbname => 'db01',
+				:password => Proc.new { 'password_via_Proc' }
+				)
+
+			expect( optstring ).to be_a( String )
+			expect( optstring ).to match( /(^|\s)dbname='db01'/ )
+			expect( optstring ).to match( /(^|\s)password='password_via_Proc'/ )
+		end
 	end
 
 	it "connects successfully with connection string" do


### PR DESCRIPTION
This short PR adds support for a lambda or Proc `:password` value in Postgres connection parameters.

This is useful for services like RDS or Lakebase that can be configured to require short-lived tokens as Postgres passwords.

For precedent, three major JS drivers (node-postgres, postgres.js, Bun.SQL) support the equivalent feature, passing a JS function as the password. For example: https://github.com/brianc/node-postgres/pull/1926

It's certainly possible I've gone about this the wrong way for ruby-pg but, if so, perhaps we can figure out the right way!