### PR TITLE
Fix incomplete transaction commit when thread is shutdown ungracefully

### DIFF
--- a/lib/pg/connection.rb
+++ b/lib/pg/connection.rb
@@ -306,30 +306,19 @@ class PG::Connection
 	# and a +COMMIT+ at the end of the block, or
 	# +ROLLBACK+ if any exception occurs.
 	def transaction
-		rollback = false
 		exec "BEGIN"
 		yield(self)
-	rescue PG::RollbackTransaction
-		rollback = true
-		perform_rollback
-	rescue Exception
-		rollback = true
-		perform_rollback
+	rescue PG::RollbackTransaction => error
+	rescue Exception => error
 		raise
 	ensure
-		unless rollback
-			if Thread.current.status == "aborting"
-				perform_rollback
-			else
-				exec("COMMIT")
-			end
+		if error || Thread.current.status == "aborting"
+			cancel if transaction_status == PG::PQTRANS_ACTIVE
+			block
+			exec("ROLLBACK")
+		else
+			exec("COMMIT")
 		end
-	end
-
-	private def perform_rollback
-		cancel if transaction_status == PG::PQTRANS_ACTIVE
-		block
-		exec("ROLLBACK")
 	end
 
 	### Returns an array of Hashes with connection defaults. See ::conndefaults

--- a/lib/pg/connection.rb
+++ b/lib/pg/connection.rb
@@ -311,17 +311,25 @@ class PG::Connection
 		yield(self)
 	rescue PG::RollbackTransaction
 		rollback = true
-		cancel if transaction_status == PG::PQTRANS_ACTIVE
-		block
-		exec "ROLLBACK"
+		perform_rollback
 	rescue Exception
 		rollback = true
-		cancel if transaction_status == PG::PQTRANS_ACTIVE
-		block
-		exec "ROLLBACK"
+		perform_rollback
 		raise
 	ensure
-		exec "COMMIT" unless rollback
+		unless rollback
+			if Thread.current.status == "aborting"
+				perform_rollback
+			else
+				exec("COMMIT")
+			end
+		end
+	end
+
+	private def perform_rollback
+		cancel if transaction_status == PG::PQTRANS_ACTIVE
+		block
+		exec("ROLLBACK")
 	end
 
 	### Returns an array of Hashes with connection defaults. See ::conndefaults

--- a/spec/pg/connection_spec.rb
+++ b/spec/pg/connection_spec.rb
@@ -1089,7 +1089,7 @@ describe PG::Connection do
 							conn.exec("INSERT INTO pie VALUES ('rhubarb'), ('cherry'), ('schizophrenia')")
 							q << 1
 							# emulate some load that keeps the transaction open
-							conn.exec("select pg_sleep(2)")
+							sleep 2
 						end
 					ensure
 						conn&.close

--- a/spec/pg/connection_spec.rb
+++ b/spec/pg/connection_spec.rb
@@ -1073,6 +1073,41 @@ describe PG::Connection do
 			end
 			expect( res ).to eq( "transaction result" )
 		end
+
+		context "when current thread gets halted in the middle of the running transaction" do
+
+			it "rollbacks the transaction" do
+				# abort the per-example transaction so we can test our own
+				@conn.exec('ROLLBACK')
+				@conn.exec("CREATE TABLE pie ( flavor TEXT )")
+
+				begin
+					q = Thread::Queue.new
+					thread = Thread.new do
+						conn = $pg_server.connect
+						conn.transaction do
+							conn.exec("INSERT INTO pie VALUES ('rhubarb'), ('cherry'), ('schizophrenia')")
+							q << 1
+							# emulate some load that keeps the transaction open
+							conn.exec("select pg_sleep(2)")
+						end
+					ensure
+						conn&.close
+					end
+					# Wait for the thread to reach the testing point
+					q.pop
+					# Terminate the thread ungracefully and wait it to die
+					thread.exit
+					thread.join
+
+					res = @conn.exec("SELECT * FROM pie")
+					expect(res.ntuples).to eq(0)
+				ensure
+					thread.exit
+					@conn.exec("DROP TABLE pie")
+				end
+			end
+		end
 	end
 
 	describe "large objects" do


### PR DESCRIPTION
### Problem description

Running transactions may suddenly commit when the thread it is running from is force-shutdown. 

### Steps to reproduce

Refer to the newly added test case

### Solution

To fix this we have to additionally check the thread status in `ensure` block and rollback in case we've been interrupted.
