### PR TITLE
Check PG::BinaryEncoder::CopyRow array input size

### DIFF
--- a/ext/pg_copy_coder.c
+++ b/ext/pg_copy_coder.c
@@ -370,6 +370,10 @@ pg_bin_enc_copy_row(t_pg_coder *conv, VALUE value, char *out, VALUE *intermediat
 	char *current_out;
 	char *end_capa_ptr;
 
+	if( RARRAY_LEN(value) >= 32768 ){
+		rb_raise( rb_eArgError, "too many columns in array for PG::BinaryEncoder::CopyRow: %ld", RARRAY_LEN(value) );
+	}
+
 	p_typemap = RTYPEDDATA_DATA( this->typemap );
 	p_typemap->funcs.fit_to_query( this->typemap, value );
 

--- a/spec/pg/type_spec.rb
+++ b/spec/pg/type_spec.rb
@@ -1434,6 +1434,10 @@ describe "PG::Type derivations" do
 						to eq("\x00\x02\x00\x00\x00\x01x\x00\x00\x00\x02yz")
 				end
 
+				it "should'nt encode too big array" do
+					expect{ encoder.encode(["x"]*32768) }.to raise_error(ArgumentError, /too many columns/)
+				end
+
 				it 'should output a string with correct character encoding' do
 					v = encoder.encode(["Héllo"], "iso-8859-1")
 					expect( v.encoding ).to eq( Encoding::ISO_8859_1 )


### PR DESCRIPTION
instead of producing an invalid output.