### PR TITLE
Suggestion: PG::Connection#embed_params

### DIFF
--- a/ext/pg_coder.c
+++ b/ext/pg_coder.c
@@ -631,7 +631,7 @@ init_pg_coder(void)
 	/*
 	 * Name of the coder or the corresponding data type.
 	 *
-	 * This accessor is only used in PG::Coder#inspect .
+	 * This accessor is used by PG::Coder#inspect and PG::Connection#embed_params .
 	 */
 	rb_define_attr(   rb_cPG_Coder, "name", 1, 1 );
 

--- a/ext/pg_connection.c
+++ b/ext/pg_connection.c
@@ -3492,12 +3492,13 @@ pgconn_async_exec(int argc, VALUE *argv, VALUE self)
  * +params+ is an array of the bind parameters for the SQL query.
  * Each element of the +params+ array may be either:
  *   a hash of the form:
- *     {:value  => String (value of bind parameter)
- *      :type   => Integer (oid of type of bind parameter)
- *      :format => Integer (0 for text, 1 for binary)
+ *     {:value    => String (value of bind parameter)
+ *      :type     => Integer (oid of type of bind parameter)
+ *      :typename => String (name of type of bind parameter, only used for conn.embed_params )
+ *      :format   => Integer (0 for text, 1 for binary)
  *     }
  *   or, it may be a String. If it is a string, that is equivalent to the hash:
- *     { :value => <string value>, :type => 0, :format => 0 }
+ *     { :value   => <string value>, :type => 0, :format => 0 }
  *
  * PostgreSQL bind parameters are represented as $1, $2, $3, etc.,
  * inside the SQL query. The 0th element of the +params+ array is bound

--- a/ext/pg_type_map.c
+++ b/ext/pg_type_map.c
@@ -115,7 +115,19 @@ pg_typemap_s_allocate( VALUE klass )
 	return self;
 }
 
-
+/*
+ * call-seq:
+ *    res.query_param_encoders(params)
+ *
+ * Retrieve the encoders that are used to encode the given values to be submitted to the database server.
+ * The selection of the encoders is defined in the derived type map class.
+ *
+ * +params+ must be an Array of values to be encoded.
+ * It's like +params+ given to exec_params .
+ *
+ * Returns an Array with the same length as +params+.
+ *
+ */
 static VALUE
 pg_typemap_query_param_encoders( VALUE self, VALUE params )
 {
@@ -129,7 +141,7 @@ pg_typemap_query_param_encoders( VALUE self, VALUE params )
 	this->funcs.fit_to_query( self, params );
 
 	nParams = RARRAY_LENINT(params);
-	res = rb_ary_new();
+	res = rb_ary_new2(nParams);
 
 	for ( i = 0; i < nParams; i++ ) {
 		t_pg_coder *conv;
@@ -137,10 +149,7 @@ pg_typemap_query_param_encoders( VALUE self, VALUE params )
 
 		/* Let the given typemap select a coder for this param */
 		conv = this->funcs.typecast_query_param(this, param_value, i);
-		if(conv)
-			rb_ary_push(res, conv->coder_obj);
-		else
-			rb_ary_push(res, Qnil);
+		rb_ary_push(res, conv ? conv->coder_obj : Qnil);
 	}
 	return res;
 }

--- a/ext/pg_type_map.c
+++ b/ext/pg_type_map.c
@@ -115,6 +115,36 @@ pg_typemap_s_allocate( VALUE klass )
 	return self;
 }
 
+
+static VALUE
+pg_typemap_query_param_encoders( VALUE self, VALUE params )
+{
+	t_typemap *this = RTYPEDDATA_DATA( self );
+	int nParams;
+	int i=0;
+	VALUE res;
+
+	Check_Type(params, T_ARRAY);
+
+	this->funcs.fit_to_query( self, params );
+
+	nParams = RARRAY_LENINT(params);
+	res = rb_ary_new();
+
+	for ( i = 0; i < nParams; i++ ) {
+		t_pg_coder *conv;
+		VALUE param_value = rb_ary_entry(params, i);
+
+		/* Let the given typemap select a coder for this param */
+		conv = this->funcs.typecast_query_param(this, param_value, i);
+		if(conv)
+			rb_ary_push(res, conv->coder_obj);
+		else
+			rb_ary_push(res, Qnil);
+	}
+	return res;
+}
+
 /*
  * call-seq:
  *    res.default_type_map = typemap
@@ -194,6 +224,7 @@ init_pg_type_map(void)
 	 */
 	rb_cTypeMap = rb_define_class_under( rb_mPG, "TypeMap", rb_cObject );
 	rb_define_alloc_func( rb_cTypeMap, pg_typemap_s_allocate );
+	rb_define_method( rb_cTypeMap, "query_param_encoders", pg_typemap_query_param_encoders, 1 );
 
 	rb_mDefaultTypeMappable = rb_define_module_under( rb_cTypeMap, "DefaultTypeMappable");
 	rb_define_method( rb_mDefaultTypeMappable, "default_type_map=", pg_typemap_default_type_map_set, 1 );

--- a/lib/pg/basic_type_map_based_on_result.rb
+++ b/lib/pg/basic_type_map_based_on_result.rb
@@ -64,4 +64,9 @@ class PG::BasicTypeMapBasedOnResult < PG::TypeMapByOid
 			add_coder(coder)
 		end
 	end
+
+	# Returns the PG::BasicTypeRegistry::CoderMapsBundle used to translate result OIDs to encoders.
+	def coder_maps_bundle
+		@coder_maps
+	end
 end

--- a/lib/pg/basic_type_map_for_queries.rb
+++ b/lib/pg/basic_type_map_for_queries.rb
@@ -57,6 +57,11 @@ class PG::BasicTypeMapForQueries < PG::TypeMapByClass
 		init_encoders
 	end
 
+	# Returns the PG::BasicTypeRegistry::CoderMapsBundle used to translate encoders to OIDs.
+	def coder_maps_bundle
+		@coder_maps
+	end
+
 	class UndefinedDefault
 		def self.call(oid_name, format)
 			raise UndefinedEncoder, "no encoder defined for type #{oid_name.inspect} format #{format}"
@@ -177,8 +182,8 @@ class PG::BasicTypeMapForQueries < PG::TypeMapByClass
 	end
 
 	DEFAULT_TYPE_MAP = PG.make_shareable({
-		TrueClass => [1, 'bool', 'bool'],
-		FalseClass => [1, 'bool', 'bool'],
+		TrueClass => [0, 'bool', 'bool'],
+		FalseClass => [0, 'bool', 'bool'],
 		# We use text format and no type OID for numbers, because setting the OID can lead
 		# to unnecessary type conversions on server side.
 		Integer => [0, 'int8'],

--- a/lib/pg/basic_type_map_for_results.rb
+++ b/lib/pg/basic_type_map_for_results.rb
@@ -101,4 +101,9 @@ class PG::BasicTypeMapForResults < PG::TypeMapByOid
 		typenames = @coder_maps.typenames_by_oid
 		self.default_type_map = WarningTypeMap.new(typenames)
 	end
+
+	# Returns the PG::BasicTypeRegistry::CoderMapsBundle used to translate result OIDs to decoders.
+	def coder_maps_bundle
+		@coder_maps
+	end
 end

--- a/lib/pg/connection.rb
+++ b/lib/pg/connection.rb
@@ -669,6 +669,68 @@ class PG::Connection
 	end
 	alias async_cancel cancel
 
+	PLACEHOLDER_RE = /
+		'(?:''|[^'])*'                                             | # string literal
+		"(?:""|[^"])*"                                             | # quoted identifier
+		--[^\n]*                                                   | # line comment
+		\/\*.*?\*\/                                                | # block comment
+		\$\$.*?\$\$                                                | # dollar-quoted string. E.g. $$ $1 $$
+		\$(?<__dq_tag>[A-Za-z_][A-Za-z_0-9]*)\$.*?\$\k<__dq_tag>\$ | # named dollar-quoted string. E.g. $foo$ $1 $foo$
+		(?<placeholder>\$(?:[1-9]\d*))                               # placeholder we are interested in
+	/mx
+	private_constant :PLACEHOLDER_RE
+
+	# call-seq:
+	#    conn.compile( sql, params ) -> String
+	#
+	# Compiles your prepared sql statement and the given positional arguments into plain sql.
+	# Example:
+	# 	res = conn.exec_params('SELECT $1 AS a, $2 AS b, $3 AS c', [1, 2, nil])
+	# 	# => "SELECT '1' AS a, '2' AS b, NULL AS c"
+	def compile(sql, params)
+		return sql if params.empty?
+
+		sql.gsub(PLACEHOLDER_RE).each do |matched|
+			placeholder = Regexp.last_match[:placeholder]
+			# Do not replace non-positional args string and pass it as is
+			next matched unless placeholder
+
+			value = params[placeholder[1..].to_i - 1]
+			value = encode_value(value)
+			normalize_value(value)
+		end
+	end
+
+	private def encode_value(value)
+		return value if type_map_for_queries.is_a?(PG::TypeMapAllStrings)
+		unless type_map_for_queries.is_a?(PG::TypeMapByClass)
+			raise <<~TEXT.strip
+				Unsupported type map. Please use the one which is inherited from PG::TypeMapByClass, for example \
+				PG::BasicTypeMapForQueries:
+				conn = PG::Connection.new
+				conn.type_map_for_queries = PG::BasicTypeMapForQueries.new(conn)
+			TEXT
+		end
+
+		encoder = type_map_for_queries[value.class]
+		return type_map_for_queries.send(encoder, value).encode(value) if encoder.is_a?(Symbol)
+		# format == 1 stands for binary format
+		return value if encoder.nil? || encoder.format == 1
+
+		encoder.encode(value)
+	end
+
+	private def normalize_value(value)
+		case value
+		when TrueClass, FalseClass
+			"#{value}"
+		when NilClass
+			'NULL'
+		else
+			"'#{self.class.escape(value.to_s)}'"
+		end
+	end
+
 	module Pollable
 		# Track the progress of the connection, waiting for the socket to become readable/writable before polling it.
 		#

--- a/lib/pg/connection.rb
+++ b/lib/pg/connection.rb
@@ -680,32 +680,66 @@ class PG::Connection
 	/mx
 	private_constant :PLACEHOLDER_RE
 
-	# call-seq:
-	#    conn.compile( sql, params ) -> String
+	# Compiles your prepared SQL statement and the given positional arguments into plain SQL string.
 	#
-	# Compiles your prepared sql statement and the given positional arguments into plain sql.
+	# The resulting SQL string can be used with +conn.exec+ like the prepared SQL statement and parameters with +conn.exec_params+.
+	# +conn.exec_params+ is usually preferred because it's faster and safer.
+	# +embed_params+ is intended for debugging messages with positional parameters.
+	# It avoids manual insertion for later inspection in +psql+ or so.
+	#
 	# Example:
-	# 	res = conn.exec_params('SELECT $1 AS a, $2 AS b, $3 AS c', [1, 2, nil])
+	# 	res = conn.embed_params('SELECT $1 AS a, $2 AS b, $3 AS c', [1, 2, nil])
 	# 	# => "SELECT '1' AS a, '2' AS b, NULL AS c"
-	def compile(sql, params)
+	def embed_params(sql, params, type_map: type_map_for_queries, coder_maps_bundle: nil)
 		return sql if params.empty?
 
-		encoders = type_map_for_queries.query_param_encoders(params)
+		oid_to_typecast = proc do |oid|
+			if oid && oid > 0
+				by_oid = if coder_maps_bundle
+					# Try to retrieve types from the method argument
+					coder_maps_bundle.typenames_by_oid
+				elsif type_map.respond_to?(:coder_maps_bundle)
+					# Try to retrieve types from the current type map
+					type_map.coder_maps_bundle.typenames_by_oid
+				elsif @typenames_by_oid
+					# Try to use cached types
+					@typenames_by_oid
+				else
+					# Load and cache types from the database server
+					@typenames_by_oid = PG::BasicTypeRegistry::CoderMapsBundle.new(self).typenames_by_oid
+				end
+				typename = by_oid[oid] || raise(ArgumentError, "cannot determine database type name of OID #{oid}")
+				"::#{ typename }"
+			end
+		end
+
+		encoders = type_map.query_param_encoders(params)
 		params = encoders.map.with_index do |enc, i|
 			value = params[i]
 			case value
-			when TrueClass, FalseClass
-				"#{value}"
 			when NilClass
 				'NULL'
 			when PG::BasicTypeMapForQueries::BinaryData
-				value = "'#{ PG::TextEncoder::Bytea.new.encode(value) }'"
+				"'#{ PG::TextEncoder::Bytea.new.encode(value) }'"
 			else
 				if enc
 					raise ArgumentError, "binary encoded data from #{enc} cannot be inserted into SQL text" if enc.format != 0
-					value = enc.encode(value)
+					"'#{escape(enc.encode(value))}'#{oid_to_typecast[enc.oid]}"
+				elsif Hash === value
+					next case value[:value]
+						when NilClass
+							'NULL'
+						else
+							if value[:format] == 1
+								raise ArgumentError, "binary encoded data with OID #{value[:type]} cannot be inserted into SQL text" if value[:type] && value[:type] != 17
+								"'#{ PG::TextEncoder::Bytea.new.encode(value[:value].to_s) }'#{oid_to_typecast[value[:type]]}"
+							else
+								"'#{escape(value[:value].to_s)}'#{oid_to_typecast[value[:type]]}"
+							end
+						end
+				else
+					"'#{escape(value.to_s)}'"
 				end
-				"'#{escape(value.to_s)}'"
 			end
 		end
 

--- a/lib/pg/connection.rb
+++ b/lib/pg/connection.rb
@@ -690,44 +690,31 @@ class PG::Connection
 	def compile(sql, params)
 		return sql if params.empty?
 
+		encoders = type_map_for_queries.query_param_encoders(params)
+		params = encoders.map.with_index do |enc, i|
+			value = params[i]
+			case value
+			when TrueClass, FalseClass
+				"#{value}"
+			when NilClass
+				'NULL'
+			when PG::BasicTypeMapForQueries::BinaryData
+				value = "'#{ PG::TextEncoder::Bytea.new.encode(value) }'"
+			else
+				if enc
+					raise ArgumentError, "binary encoded data from #{enc} cannot be inserted into SQL text" if enc.format != 0
+					value = enc.encode(value)
+				end
+				"'#{escape(value.to_s)}'"
+			end
+		end
+
 		sql.gsub(PLACEHOLDER_RE).each do |matched|
 			placeholder = Regexp.last_match[:placeholder]
 			# Do not replace non-positional args string and pass it as is
 			next matched unless placeholder
 
-			value = params[placeholder[1..].to_i - 1]
-			value = encode_value(value)
-			normalize_value(value)
-		end
-	end
-
-	private def encode_value(value)
-		return value if type_map_for_queries.is_a?(PG::TypeMapAllStrings)
-		unless type_map_for_queries.is_a?(PG::TypeMapByClass)
-			raise <<~TEXT.strip
-				Unsupported type map. Please use the one which is inherited from PG::TypeMapByClass, for example \
-				PG::BasicTypeMapForQueries:
-				conn = PG::Connection.new
-				conn.type_map_for_queries = PG::BasicTypeMapForQueries.new(conn)
-			TEXT
-		end
-
-		encoder = type_map_for_queries[value.class]
-		return type_map_for_queries.send(encoder, value).encode(value) if encoder.is_a?(Symbol)
-		# format == 1 stands for binary format
-		return value if encoder.nil? || encoder.format == 1
-
-		encoder.encode(value)
-	end
-
-	private def normalize_value(value)
-		case value
-		when TrueClass, FalseClass
-			"#{value}"
-		when NilClass
-			'NULL'
-		else
-			"'#{self.class.escape(value.to_s)}'"
+			params[placeholder[1..].to_i - 1]
 		end
 	end
 

--- a/lib/pg/connection.rb
+++ b/lib/pg/connection.rb
@@ -720,7 +720,7 @@ class PG::Connection
 			when NilClass
 				'NULL'
 			when PG::BasicTypeMapForQueries::BinaryData
-				"'#{ PG::TextEncoder::Bytea.new.encode(value) }'"
+				"'#{ escape_bytea(value) }'"
 			else
 				if enc
 					raise ArgumentError, "binary encoded data from #{enc} cannot be inserted into SQL text" if enc.format != 0
@@ -732,7 +732,7 @@ class PG::Connection
 						else
 							if value[:format] == 1
 								raise ArgumentError, "binary encoded data with OID #{value[:type]} cannot be inserted into SQL text" if value[:type] && value[:type] != 17
-								"'#{ PG::TextEncoder::Bytea.new.encode(value[:value].to_s) }'#{oid_to_typecast[value[:type]]}"
+								"'#{ escape_bytea(value[:value].to_s) }'#{oid_to_typecast[value[:type]]}"
 							else
 								"'#{escape(value[:value].to_s)}'#{oid_to_typecast[value[:type]]}"
 							end

--- a/lib/pg/connection.rb
+++ b/lib/pg/connection.rb
@@ -687,29 +687,27 @@ class PG::Connection
 	# +embed_params+ is intended for debugging messages with positional parameters.
 	# It avoids manual insertion for later inspection in +psql+ or so.
 	#
+	# When using PG::Connection#exec_params, it's possible to set the numeric database type OID of a parameter by either a hash with +:type+ key, or by PG::Coder#oid .
+	# +embed_params+ casts the parameter the same way, but needs the name of the type instead its OID.
+	# That name must be provided by either a +:typename+ key in addition to the +:type+ OID or by PG::Coder#name in addition to PG::Coder#oid.
+	#
+	# Only text parameter format can be embedded into SQL text.
+	# Binary data ( <tt>:format => 1</tt> or PG::Coder#format == 1 ) raises an ArgumentError.
+	# However the common pattern of sending BYTEA (OID 17) data as format 1, which avoids escapting large blobs, is recognized and probably escaped into the SQL result string.
+	#
 	# Example:
-	# 	res = conn.embed_params('SELECT $1 AS a, $2 AS b, $3 AS c', [1, 2, nil])
-	# 	# => "SELECT '1' AS a, '2' AS b, NULL AS c"
-	def embed_params(sql, params, type_map: type_map_for_queries, coder_maps_bundle: nil)
+	# 	conn.embed_params('SELECT $1 AS a, $2 AS b, $3 AS c', [1, 2, {value: "\0", type: 17, format: 1}])
+	# 	=> "SELECT '1' AS a, '2' AS b, '\\x00'::bytea AS c"
+	def embed_params(sql, params, type_map: type_map_for_queries)
 		return sql if params.empty?
 
-		oid_to_typecast = proc do |oid|
+		oid_to_typecast = proc do |oid, tname, errtext|
 			if oid && oid > 0
-				by_oid = if coder_maps_bundle
-					# Try to retrieve types from the method argument
-					coder_maps_bundle.typenames_by_oid
-				elsif type_map.respond_to?(:coder_maps_bundle)
-					# Try to retrieve types from the current type map
-					type_map.coder_maps_bundle.typenames_by_oid
-				elsif @typenames_by_oid
-					# Try to use cached types
-					@typenames_by_oid
+				if tname.to_s.empty?
+					raise(ArgumentError, "Database type name of OID #{oid.inspect} missing#{errtext}")
 				else
-					# Load and cache types from the database server
-					@typenames_by_oid = PG::BasicTypeRegistry::CoderMapsBundle.new(self).typenames_by_oid
+					"::#{ tname }"
 				end
-				typename = by_oid[oid] || raise(ArgumentError, "cannot determine database type name of OID #{oid}")
-				"::#{ typename }"
 			end
 		end
 
@@ -723,20 +721,23 @@ class PG::Connection
 				"'#{ escape_bytea(value) }'"
 			else
 				if enc
-					raise ArgumentError, "binary encoded data from #{enc} cannot be inserted into SQL text" if enc.format != 0
-					"'#{escape(enc.encode(value))}'#{oid_to_typecast[enc.oid]}"
+					raise ArgumentError, "binary encoded parameter from #{enc.inspect} cannot be inserted into SQL text" if enc.format != 0
+					"'#{escape(enc.encode(value))}'#{oid_to_typecast[enc.oid, enc.name, " - please set name of encoder #{enc.inspect}"]}"
 				elsif Hash === value
-					next case value[:value]
-						when NilClass
-							'NULL'
+					typename = value[:format] == 1 && value[:type] == 17 ?
+						"::bytea" : oid_to_typecast[value[:type], value[:typename], " - please set parameter key :typename"]
+
+					case value[:value]
+					when NilClass
+						"NULL#{typename}"
+					else
+						if value[:format] == 1
+							raise ArgumentError, "binary encoded parameter with OID #{value[:type].inspect} cannot be inserted into SQL text" if value[:type] && value[:type] != 17
+							"'#{escape_bytea(value[:value].to_s)}'#{typename}"
 						else
-							if value[:format] == 1
-								raise ArgumentError, "binary encoded data with OID #{value[:type]} cannot be inserted into SQL text" if value[:type] && value[:type] != 17
-								"'#{ escape_bytea(value[:value].to_s) }'#{oid_to_typecast[value[:type]]}"
-							else
-								"'#{escape(value[:value].to_s)}'#{oid_to_typecast[value[:type]]}"
-							end
+							"'#{escape(value[:value].to_s)}'#{typename}"
 						end
+					end
 				else
 					"'#{escape(value.to_s)}'"
 				end

--- a/spec/pg/basic_type_map_based_on_result_spec.rb
+++ b/spec/pg/basic_type_map_based_on_result_spec.rb
@@ -13,6 +13,7 @@ describe 'Basic type mapping' do
 			maps = PG::BasicTypeRegistry::CoderMapsBundle.new(@conn).freeze
 			tm = PG::BasicTypeMapBasedOnResult.new(maps)
 			expect( tm.rm_coder(0, 16) ).to be_kind_of(PG::TextEncoder::Boolean)
+			expect( tm.coder_maps_bundle ).to eq(maps)
 		end
 
 		it "can be initialized with a custom type registry" do

--- a/spec/pg/basic_type_map_for_queries_spec.rb
+++ b/spec/pg/basic_type_map_for_queries_spec.rb
@@ -39,6 +39,7 @@ describe 'Basic type mapping' do
 			maps = PG::BasicTypeRegistry::CoderMapsBundle.new(@conn).freeze
 			tm = PG::BasicTypeMapForQueries.new(maps)
 			expect( tm[Integer] ).to be_kind_of(PG::TextEncoder::Integer)
+			expect( tm.coder_maps_bundle ).to eq(maps)
 		end
 
 		it "can be initialized with a custom type registry" do
@@ -54,7 +55,7 @@ describe 'Basic type mapping' do
 			args = []
 			pr = proc { |*a| args << a }
 			PG::BasicTypeMapForQueries.new(@conn, registry: regi, if_undefined: pr)
-			expect( args.first ).to eq( ["bool", 1] )
+			expect( args.first ).to eq( ["bool", 0] )
 		end
 
 		it "raises UndefinedEncoder for undefined types" do

--- a/spec/pg/basic_type_map_for_results_spec.rb
+++ b/spec/pg/basic_type_map_for_results_spec.rb
@@ -15,6 +15,7 @@ describe 'Basic type mapping' do
 			maps = PG::BasicTypeRegistry::CoderMapsBundle.new(@conn).freeze
 			tm = PG::BasicTypeMapForResults.new(maps)
 			expect( tm.rm_coder(0, 16) ).to be_kind_of(PG::TextDecoder::Boolean)
+			expect( tm.coder_maps_bundle ).to eq(maps)
 		end
 
 		it "can be initialized with a custom type registry" do

--- a/spec/pg/connection_spec.rb
+++ b/spec/pg/connection_spec.rb
@@ -3105,6 +3105,16 @@ describe PG::Connection do
 
 				expect(@conn2.exec(compiled).first).to(eq("one" => "', '1"))
 			end
+
+			it "encodes binary strings properly" do
+				binary = PG::BasicTypeMapForQueries::BinaryData.new("\0\xff\r\n\t'".b)
+				compiled = @conn2.compile(<<~SQL, [binary])
+					select $1::bytea as one
+				SQL
+
+				res = @conn2.exec(compiled).first
+				expect(res["one"]).to(eq(binary))
+			end
 		end
 	end
 

--- a/spec/pg/connection_spec.rb
+++ b/spec/pg/connection_spec.rb
@@ -3013,6 +3013,101 @@ describe PG::Connection do
 		end
 	end
 
+	describe :compile do
+		describe "default type map" do
+			it "compiles prepared sql into plain sql" do
+				compiled = @conn.compile(<<~SQL, [1, "2", true, false, nil])
+					-- this is one: $1
+					/* this is another one: $1 */
+					select $1::int as a, $2 as b, $3 as c, $4 as d, $5 as e, '$5' as f, $$ $6 $$ as g, -- this is two: $2
+							$body$ $1 $body$ as h, t."$1", t."$2"
+					from (select 10 as "$1", 20 as "$2") as t
+				SQL
+				
+				aggregate_failures do
+					expect(compiled).to include("-- this is one: $1")
+					expect(compiled).to include("/* this is another one: $1 */")
+					expect(compiled).to include("-- this is two: $2")
+					expect(@conn.exec(compiled).first).to(
+						eq(
+							"a" => "1",
+							"b" => "2",
+							"c" => "t",
+							"d" => "f",
+							"e" => nil,
+							"f" => "$5",
+							"g" => " $6 ",
+							"h" => " $1 ",
+							"$1" => "10",
+							"$2" => "20",
+						), compiled
+					)
+				end
+			end
+			
+			it "escapes strings properly" do
+				compiled = @conn.compile(<<~SQL, ["', '1"])
+					select $1 as one
+				SQL
+
+				expect(@conn.exec(compiled).first).to(eq("one" => "', '1"))
+			end
+		end
+		
+		describe "PG::TypeMapByClass type map" do
+			before do
+				@conn2 = PG.connect(@conninfo)
+				@conn2.type_map_for_queries = PG::BasicTypeMapForQueries.new(@conn2)
+				@conn2.type_map_for_results = PG::BasicTypeMapForResults.new(@conn2)
+			end
+
+			after do
+				@conn2.close
+			end
+
+			it "compiles prepared sql into plain sql" do
+				compiled = @conn2.compile(<<~SQL, [1, "2", { foo: :bar }, [1], true, false, nil])
+					-- this is one: $1
+					/* this is another one: $1 */
+					select $1::int as a, $2 as b, $3::json as c, $4::int[] as d, '$5' as e, $$ $6 $$ as f,
+						$body$ $1 $body$ as g, -- this is two: $2
+						t."$1", t."$2", $5 as h, $6 as i, $7 j
+					from (select 10 as "$1", 20 as "$2") as t
+				SQL
+
+				aggregate_failures do
+					expect(compiled).to include("-- this is one: $1")
+					expect(compiled).to include("/* this is another one: $1 */")
+					expect(compiled).to include("-- this is two: $2")
+					expect(@conn2.exec(compiled).first).to(
+						eq(
+							"a" => 1,
+							"b" => "2",
+							"c" => { "foo" => "bar" },
+							"d" => [1],
+							"e" => "$5",
+							"f" => " $6 ",
+							"g" => " $1 ",
+							"$1" => 10,
+							"$2" => 20,
+							"h" => true,
+							"i" => false,
+							"j" => nil
+						)
+					)
+				end
+			end
+
+			it "escapes strings properly" do
+				compiled = @conn2.compile(<<~SQL, ["', '1"])
+					select $1 as one
+				SQL
+
+				expect(@conn2.exec(compiled).first).to(eq("one" => "', '1"))
+			end
+		end
+	end
+
 	describe "deprecated forms of methods" do
 		if PG::VERSION < "2"
 			it "should forward exec to exec_params" do

--- a/spec/pg/connection_spec.rb
+++ b/spec/pg/connection_spec.rb
@@ -3013,10 +3013,20 @@ describe PG::Connection do
 		end
 	end
 
-	describe :compile do
+	describe :embed_params do
+
+		def embed_params_and_check(sql, params, conn: @conn)
+			compiled = conn.embed_params(sql, params)
+
+			res = conn.exec(compiled)
+			res2 = conn.exec_params(sql, params)
+			expect( res.to_a ).to eq( res2.to_a ), compiled
+			compiled
+		end
+
 		describe "default type map" do
 			it "compiles prepared sql into plain sql" do
-				compiled = @conn.compile(<<~SQL, [1, "2", true, false, nil])
+				compiled = embed_params_and_check(<<~SQL, [1, "2", true, false, nil])
 					-- this is one: $1
 					/* this is another one: $1 */
 					select $1::int as a, $2 as b, $3 as c, $4 as d, $5 as e, '$5' as f, $$ $6 $$ as g, -- this is two: $2
@@ -3028,29 +3038,32 @@ describe PG::Connection do
 					expect(compiled).to include("-- this is one: $1")
 					expect(compiled).to include("/* this is another one: $1 */")
 					expect(compiled).to include("-- this is two: $2")
-					expect(@conn.exec(compiled).first).to(
-						eq(
-							"a" => "1",
-							"b" => "2",
-							"c" => "t",
-							"d" => "f",
-							"e" => nil,
-							"f" => "$5",
-							"g" => " $6 ",
-							"h" => " $1 ",
-							"$1" => "10",
-							"$2" => "20",
-						), compiled
-					)
 				end
 			end
 			
 			it "escapes strings properly" do
-				compiled = @conn.compile(<<~SQL, ["', '1"])
+				embed_params_and_check(<<~SQL, ["', '1"])
 					select $1 as one
 				SQL
+			end
 
-				expect(@conn.exec(compiled).first).to(eq("one" => "', '1"))
+			context "with params as Hash" do
+				it "encodes values properly" do
+					params = [
+						{value: "\0\xff\r\n\t2'".b, format: 1},
+						{value: "\0\xff\r\n\t1'".b, format: 1, type: 17},
+						{value: "abc"},
+						{value: 4},
+						{value: 5, type: 23},
+						{value: "{ 6, 7}", type: 1007},
+						{value: false},
+						{value: "\\x000102ff", type: 17},
+						{value: nil}
+					]
+					embed_params_and_check <<~SQL, params
+						select $1::bytea as a, $2 as b, $3 as c, $4 as d, $5 as e, $6 as f, $7 as g, $8 as h, $9 as i
+					SQL
+				end
 			end
 		end
 		
@@ -3066,7 +3079,7 @@ describe PG::Connection do
 			end
 
 			it "compiles prepared sql into plain sql" do
-				compiled = @conn2.compile(<<~SQL, [1, "2", { foo: :bar }, [1], true, false, nil])
+				compiled = embed_params_and_check(<<~SQL, [1, "2", { foo: :bar }, [1], true, false, nil], conn: @conn2)
 					-- this is one: $1
 					/* this is another one: $1 */
 					select $1::int as a, $2 as b, $3::json as c, $4::int[] as d, '$5' as e, $$ $6 $$ as f,
@@ -3079,41 +3092,20 @@ describe PG::Connection do
 					expect(compiled).to include("-- this is one: $1")
 					expect(compiled).to include("/* this is another one: $1 */")
 					expect(compiled).to include("-- this is two: $2")
-					expect(@conn2.exec(compiled).first).to(
-						eq(
-							"a" => 1,
-							"b" => "2",
-							"c" => { "foo" => "bar" },
-							"d" => [1],
-							"e" => "$5",
-							"f" => " $6 ",
-							"g" => " $1 ",
-							"$1" => 10,
-							"$2" => 20,
-							"h" => true,
-							"i" => false,
-							"j" => nil
-						)
-					)
 				end
 			end
 
 			it "escapes strings properly" do
-				compiled = @conn2.compile(<<~SQL, ["', '1"])
+				embed_params_and_check(<<~SQL, ["', '1"], conn: @conn2)
 					select $1 as one
 				SQL
-
-				expect(@conn2.exec(compiled).first).to(eq("one" => "', '1"))
 			end
 
 			it "encodes binary strings properly" do
 				binary = PG::BasicTypeMapForQueries::BinaryData.new("\0\xff\r\n\t'".b)
-				compiled = @conn2.compile(<<~SQL, [binary])
+				embed_params_and_check(<<~SQL, [binary], conn: @conn2)
 					select $1::bytea as one
 				SQL
-
-				res = @conn2.exec(compiled).first
-				expect(res["one"]).to(eq(binary))
 			end
 		end
 	end

--- a/spec/pg/connection_spec.rb
+++ b/spec/pg/connection_spec.rb
@@ -3024,6 +3024,15 @@ describe PG::Connection do
 			compiled
 		end
 
+		def with_std_conf_strings(conn, onoff)
+			conn.exec("SET standard_conforming_strings = #{onoff}")
+			conn.exec("SET escape_string_warning = #{onoff}")
+			yield
+		ensure
+			conn.exec("SET standard_conforming_strings = on")
+			conn.exec("SET escape_string_warning = on")
+		end
+
 		describe "default type map" do
 			it "compiles prepared sql into plain sql" do
 				compiled = embed_params_and_check(<<~SQL, [1, "2", true, false, nil])
@@ -3048,21 +3057,26 @@ describe PG::Connection do
 			end
 
 			context "with params as Hash" do
-				it "encodes values properly" do
-					params = [
-						{value: "\0\xff\r\n\t2'".b, format: 1},
-						{value: "\0\xff\r\n\t1'".b, format: 1, type: 17},
-						{value: "abc"},
-						{value: 4},
-						{value: 5, type: 23},
-						{value: "{ 6, 7}", type: 1007},
-						{value: false},
-						{value: "\\x000102ff", type: 17},
-						{value: nil}
-					]
-					embed_params_and_check <<~SQL, params
-						select $1::bytea as a, $2 as b, $3 as c, $4 as d, $5 as e, $6 as f, $7 as g, $8 as h, $9 as i
-					SQL
+
+				['on', 'off'].each do |stdconf|
+					it "encodes values properly with std conforming strings=#{stdconf}" do
+						with_std_conf_strings(@conn, stdconf) do
+							params = [
+								{value: "'\x1F\\".b, format: 1},
+								{value: "'\0\xff\r\n\t1'".b, format: 1, type: 17},
+								{value: "abc"},
+								{value: 4},
+								{value: 5, type: 23},
+								{value: "{ 6, 7}", type: 1007},
+								{value: false},
+								{value: "\\x000102ff", type: 17},
+								{value: nil}
+							]
+							embed_params_and_check <<~SQL, params
+								select $1::bytea as a, $2 as b, $3 as c, $4 as d, $5 as e, $6 as f, $7 as g, $8 as h, $9 as i
+							SQL
+						end
+					end
 				end
 			end
 		end
@@ -3101,11 +3115,15 @@ describe PG::Connection do
 				SQL
 			end
 
-			it "encodes binary strings properly" do
-				binary = PG::BasicTypeMapForQueries::BinaryData.new("\0\xff\r\n\t'".b)
-				embed_params_and_check(<<~SQL, [binary], conn: @conn2)
-					select $1::bytea as one
-				SQL
+			['on', 'off'].each do |stdconf|
+				it "encodes binary strings properly with std conforming strings=#{stdconf}" do
+					with_std_conf_strings(@conn, stdconf) do
+						binary = PG::BasicTypeMapForQueries::BinaryData.new("''\0\xff\r\n\t'".b)
+						embed_params_and_check(<<~SQL, [binary], conn: @conn2)
+							select $1::bytea as one
+						SQL
+					end
+				end
 			end
 		end
 	end

--- a/spec/pg/connection_spec.rb
+++ b/spec/pg/connection_spec.rb
@@ -3021,6 +3021,7 @@ describe PG::Connection do
 			res = conn.exec(compiled)
 			res2 = conn.exec_params(sql, params)
 			expect( res.to_a ).to eq( res2.to_a ), compiled
+			expect( result_typenames(res) ).to eq( result_typenames(res2) ), compiled
 			compiled
 		end
 
@@ -3042,14 +3043,14 @@ describe PG::Connection do
 							$body$ $1 $body$ as h, t."$1", t."$2"
 					from (select 10 as "$1", 20 as "$2") as t
 				SQL
-				
+
 				aggregate_failures do
 					expect(compiled).to include("-- this is one: $1")
 					expect(compiled).to include("/* this is another one: $1 */")
 					expect(compiled).to include("-- this is two: $2")
 				end
 			end
-			
+
 			it "escapes strings properly" do
 				embed_params_and_check(<<~SQL, ["', '1"])
 					select $1 as one
@@ -3066,21 +3067,55 @@ describe PG::Connection do
 								{value: "'\0\xff\r\n\t1'".b, format: 1, type: 17},
 								{value: "abc"},
 								{value: 4},
-								{value: 5, type: 23},
-								{value: "{ 6, 7}", type: 1007},
+								{value: 5, type: 23, typename: 'int'},
+								{value: "{ 6, 7}", type: 1007, typename: 'int[]'},
 								{value: false},
-								{value: "\\x000102ff", type: 17},
+								{value: "\\x000102ff", type: 17, typename: 'bytea'},
+								{value: nil, format: 1, type: 17},
+								{value: nil, format: 1},
 								{value: nil}
-							]
+								]
 							embed_params_and_check <<~SQL, params
-								select $1::bytea as a, $2 as b, $3 as c, $4 as d, $5 as e, $6 as f, $7 as g, $8 as h, $9 as i
+								select $1::bytea as a, $2 as b, $3 as c, $4 as d, $5 as e, $6 as f, $7 as g, $8 as h, $9 as i, $10 as j, $11 as k
 							SQL
 						end
 					end
 				end
+
+				it "doesn't cast value" do
+					res = @conn.embed_params("SELECT $1", [{value: "22"}])
+					expect( res ).to eq("SELECT '22'")
+				end
+
+				it "doesn't cast value even if name is given" do
+					res = @conn.embed_params("SELECT $1", [{value: "22", typename: 'int8'}])
+					expect( res ).to eq("SELECT '22'")
+				end
+
+				it "casts value" do
+					res = @conn.embed_params("SELECT $1", [value: "22", typename: 'int8', type: 20])
+					expect( res ).to eq("SELECT '22'::int8")
+				end
+
+				it "assumes bytea data when format: 1" do
+					res = @conn.embed_params("SELECT $1", [value: "\0", format: 1])
+					expect( res ).to eq("SELECT '\\x00'")
+				end
+
+				it "fails to encode binary format" do
+					expect do
+						@conn.embed_params("SELECT $1", [{value: "x", format: 1, type: 20, typename: "int8"}])
+					end.to raise_error(ArgumentError, /binary encoded parameter/)
+				end
+
+				it "fails to encode OID without name" do
+					expect do
+						@conn.embed_params("SELECT $1", [{value: "1", type: 20}])
+					end.to raise_error(ArgumentError, /OID 20 missing.*key :typename/)
+				end
 			end
 		end
-		
+
 		describe "PG::TypeMapByClass type map" do
 			before do
 				@conn2 = PG.connect(@conninfo)
@@ -3124,6 +3159,45 @@ describe PG::Connection do
 						SQL
 					end
 				end
+			end
+		end
+
+		describe "with explicit :type_map" do
+			it "doesn't cast value" do
+				enc = PG::TextEncoder::Integer.new
+				tm = PG::TypeMapByColumn.new([enc])
+				res = @conn.embed_params("SELECT $1", ["22"], type_map: tm)
+				expect( res ).to eq("SELECT '22'")
+			end
+
+			it "doesn't cast value even if name is given" do
+				enc = PG::TextEncoder::Integer.new name: 'int8'
+				tm = PG::TypeMapByColumn.new([enc])
+				res = @conn.embed_params("SELECT $1", ["22"], type_map: tm)
+				expect( res ).to eq("SELECT '22'")
+			end
+
+			it "casts value" do
+				enc = PG::TextEncoder::Integer.new oid: 20, name: 'int8'
+				tm = PG::TypeMapByColumn.new([enc])
+				res = @conn.embed_params("SELECT $1", ["22"], type_map: tm)
+				expect( res ).to eq("SELECT '22'::int8")
+			end
+
+			it "fails to encode binary format" do
+				enc = PG::BinaryEncoder::Int4.new
+				tm = PG::TypeMapByColumn.new([enc])
+				expect do
+					@conn.embed_params("SELECT $1", ["x"], type_map: tm)
+				end.to raise_error(ArgumentError, /binary encoded parameter/)
+			end
+
+			it "fails to encode OID without name" do
+				enc = PG::TextEncoder::Integer.new oid: 20
+				tm = PG::TypeMapByColumn.new([enc])
+				expect do
+					@conn.embed_params("SELECT $1", ["y"], type_map: tm)
+				end.to raise_error(ArgumentError, /OID 20 missing.*name of encoder/)
 			end
 		end
 	end

--- a/spec/pg/connection_spec.rb
+++ b/spec/pg/connection_spec.rb
@@ -3034,6 +3034,23 @@ describe PG::Connection do
 			conn.exec("SET escape_string_warning = on")
 		end
 
+		it "ensures PostgreSQL string syntax does not change" do
+			require "net/http"
+			require "json"
+
+			latest_commit_uri = URI(
+				"https://api.github.com/repos/postgres/postgres/commits?sha=master&path=doc/src/sgml/syntax.sgml&per_page=1"
+			)
+			latest_commit_info = JSON.parse(Net::HTTP.get(latest_commit_uri), symbolize_names: true)
+			error_message = <<~TEXT
+				PostgreSQL syntax has changed. Please make sure no new string literals were added by inspecting changelog
+				https://www.postgresql.org/docs/current/release.html and syntax page
+				https://www.postgresql.org/docs/current/sql-syntax-lexical.html. Should you find any syntax changes in
+				string literals - please adjust PG::Connection::PLACEHOLDER_RE constant accordingly
+			TEXT
+			expect(latest_commit_info.dig(0, :sha)).to eq("45762084545ec14dbbe66ace1d69d7e89f8978ac"), error_message
+		end
+
 		describe "default type map" do
 			it "compiles prepared sql into plain sql" do
 				compiled = embed_params_and_check(<<~SQL, [1, "2", true, false, nil])


### PR DESCRIPTION
Introduce `PG::Connection#complile` that take sql string and position parameters and compiles it into a plain sql. I couldn't find another way how to do it using built-in tools. The motivation behind this implementation:

- debugging sql queries. When you have queries with dozens(or even hundreds) of positional parameters - it is pretty cancer to replace each positional param by hands for later inspection
- such feature as [PostreSQL view](https://www.postgresql.org/docs/current/sql-createview.html) does not support positional parameters and requires pre-computed sql string. So, imaging you have some sql builder in your app that results in sql with positional params. And now you need to work with PostgreSQL view which does not support them. You will end up implementing very similar to the changes in this PR or somehow compute an sql string based on your app's logic. Both variants would be annoying.

The downside of this implementation is that it can't reliably encode binary data into a string representation except some common cases like with booleans, but do we need them at all?