### PR TITLE
CI: Update actions to versions running on Node.js 24

### DIFF
--- a/.github/workflows/binary-gems.yml
+++ b/.github/workflows/binary-gems.yml
@@ -35,7 +35,7 @@ jobs:
           - platform: "x86_64-darwin"
           - platform: "arm64-darwin"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
@@ -53,7 +53,7 @@ jobs:
         run: bundle exec rake gem:native:${{ matrix.platform }}
 
       - name: Upload binary gem
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: binary-gem-${{ matrix.platform }}
           path: pkg/*.gem
@@ -101,7 +101,7 @@ jobs:
     env:
       PGVERSION: ${{ matrix.PGVERSION }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Set up Ruby
         if: matrix.platform != 'x86-mingw32'
         uses: ruby/setup-ruby-pkgs@v1
@@ -123,7 +123,7 @@ jobs:
           echo "C:/msys64/$env:MSYSTEM_PREFIX/bin"  | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
 
       - name: Download gem from build job
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: binary-gem-${{ matrix.platform }}
 
@@ -200,9 +200,9 @@ jobs:
 
     runs-on: ${{ matrix.os || 'ubuntu-latest' }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Download gem-${{ matrix.gem_platform }}
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: binary-gem-${{ matrix.gem_platform }}
       - name: Build image and Run tests
@@ -221,9 +221,9 @@ jobs:
 
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Download gem-${{ matrix.gem_platform }}
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: binary-gem-${{ matrix.gem_platform }}
       - name: Build image and Run tests
@@ -244,9 +244,9 @@ jobs:
 
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Download gem-${{ matrix.gem_platform }}
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: binary-gem-${{ matrix.gem_platform }}
       - name: Build image and Run tests

--- a/.github/workflows/source-gem.yml
+++ b/.github/workflows/source-gem.yml
@@ -20,7 +20,7 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
@@ -30,7 +30,7 @@ jobs:
         run: gem build pg.gemspec
 
       - name: Upload source gem
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: source-gem
           path: "*.gem"
@@ -82,7 +82,7 @@ jobs:
       MAKE: make -j2 V=1
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
@@ -95,7 +95,7 @@ jobs:
           gcc -v
 
       - name: Download gem from build job
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: source-gem
 


### PR DESCRIPTION
Workflow runs emit this warning, e.g. https://github.com/ged/ruby-pg/actions/runs/30111076146

> Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24: actions/checkout@v4, actions/upload-artifact@v4. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/

This updates checkout to v7, upload-artifact to v7 and download-artifact to v8, which run on Node.js 24 natively.


