### PR TITLE
Fix some typos

### DIFF
--- a/ext/pg_cancel_connection.c
+++ b/ext/pg_cancel_connection.c
@@ -6,7 +6,7 @@
  *
  * The class to represent a connection to cancel a query.
  *
- * On PostgreSQL-17+ client libaray this class is used to implement PG::Connection#cancel .
+ * On PostgreSQL-17+ client library this class is used to implement PG::Connection#cancel .
  * It works on older PostgreSQL server versions too.
  *
  * Available since PostgreSQL-17

--- a/lib/pg/connection.rb
+++ b/lib/pg/connection.rb
@@ -620,7 +620,7 @@ class PG::Connection
 		# Returns +nil+ on success, or a string containing the
 		# error message if a failure occurs.
 		#
-		# On PostgreSQL-17+ client libaray the class PG::CancelConnection is used.
+		# On PostgreSQL-17+ client library the class PG::CancelConnection is used.
 		# On older client library a pure ruby implementation is used.
 		def cancel
 			cancon = PG::CancelConnection.new(self)
@@ -678,7 +678,7 @@ class PG::Connection
 		# - All hosts are passed to PG::Connection.connect_start
 		# - As soon as the host is tried to connect the related host is removed from the hosts list
 		# - When the polling status changes to `PG::PGRES_POLLING_OK` the connection is returned and ready to use.
-		# - When the polling status changes to `PG::PGRES_POLLING_FAILED` connecting is aborted and a PG::ConnectionBad is raised with details to all connection attepts.
+		# - When the polling status changes to `PG::PGRES_POLLING_FAILED` connecting is aborted and a PG::ConnectionBad is raised with details to all connection attempts.
 		# - When a timeout occurs, connecting is restarted with the remaining hosts.
 		#
 		# The downside is that this connects only once to hosts which are listed twice when they timeout.

--- a/sample/async_mixed.rb
+++ b/sample/async_mixed.rb
@@ -5,7 +5,7 @@ require 'pg'
 $stdout.sync = true
 
 # This is a example of how to mix and match synchronous and async APIs. In this case,
-# the connection to the server is made syncrhonously, and then queries are
+# the connection to the server is made synchronously, and then queries are
 # asynchronous.
 
 TIMEOUT = 5.0 # seconds to wait for an async operation to complete

--- a/spec/pg/cancel_connection_spec.rb
+++ b/spec/pg/cancel_connection_spec.rb
@@ -6,7 +6,7 @@ require 'pg'
 
 if PG.library_version < 170000
 
-	context "query cancelation" do
+	context "query cancellation" do
 		it "shouldn't define PG::CancelConnection" do
 			expect( !defined?(PG::CancelConnection) )
 		end

--- a/spec/pg/type_spec.rb
+++ b/spec/pg/type_spec.rb
@@ -867,7 +867,7 @@ describe "PG::Type derivations" do
 							end.to raise_error(ArgumentError, /premature/)
 						end
 					end
-					it 'raises error when binary array has additonal bytes' do
+					it 'raises error when binary array has additional bytes' do
 						expect do
 							binarydec_int_array.decode(bin_int_array_data + "\0")
 						end.to raise_error(ArgumentError, /trailing/)
@@ -1453,7 +1453,7 @@ describe "PG::Type derivations" do
 						to eq("\x00\x02\x00\x00\x00\x01x\x00\x00\x00\x02yz")
 				end
 
-				it "should'nt encode too big array" do
+				it "shouldn't encode too big array" do
 					expect{ encoder.encode(["x"]*32768) }.to raise_error(ArgumentError, /too many columns/)
 				end
 

--- a/spec/pg_spec.rb
+++ b/spec/pg_spec.rb
@@ -73,7 +73,7 @@ describe PG do
 		cext_fname = $LOADED_FEATURES.grep(/pg_ext/).first
 		expect(cext_fname).not_to be_nil
 		cext_text = File.binread(cext_fname)
-		expect(cext_text).to match(/Init_pg_ext/) # C-ext shoud contain the init function
+		expect(cext_text).to match(/Init_pg_ext/) # C-ext should contain the init function
 		expect(cext_text).not_to match(/usr\/local/) # there should be no rpath to /usr/local/rake-compiler/ruby/x86_64-unknown-linux-musl/ruby-3.4.5/lib or so
 		expect(cext_text).not_to match(/home\//) # there should be no path to /home/ or so
 	end
@@ -89,7 +89,7 @@ describe PG do
 
 		path = File.join(PG::POSTGRESQL_LIB_PATH, libpq_fname)
 		text = File.binread(path)
-		expect(text).to match(/PQconnectdb/) # libpq shoud contain the connect function
+		expect(text).to match(/PQconnectdb/) # libpq should contain the connect function
 		expect(text).not_to match(/usr\/local/) # there should be no rpath to build dirs
 		expect(text).not_to match(/home\//) # there should be no path to /home/.../ports/ or so
 	end


### PR DESCRIPTION
Fixes typos found via `codespell`.

All changes are limited to code comments, documentation and spec descriptions, so there is no behavior change and no API is affected.