### PR TITLE
Remove option "quirks_mode" from JSON en/decoder

### DIFF
--- a/lib/pg/text_decoder/json.rb
+++ b/lib/pg/text_decoder/json.rb
@@ -10,7 +10,7 @@ module PG
 		# As soon as this class is used, it requires the ruby standard library 'json'.
 		class JSON < SimpleDecoder
 			def decode(string, tuple=nil, field=nil)
-				::JSON.parse(string, quirks_mode: true)
+				::JSON.parse(string)
 			end
 		end
 	end

--- a/lib/pg/text_encoder/json.rb
+++ b/lib/pg/text_encoder/json.rb
@@ -10,7 +10,7 @@ module PG
 		# As soon as this class is used, it requires the ruby standard library 'json'.
 		class JSON < SimpleEncoder
 			def encode(value)
-				::JSON.generate(value, quirks_mode: true)
+				::JSON.generate(value)
 			end
 		end
 	end


### PR DESCRIPTION
The option was introduces as part of https://github.com/ged/ruby-pg/issues/248 . However the "quirks_mode" was removed short time later from json gem:
  https://github.com/ruby/json/commit/7d2ad6d6556da03300a5aeadeeacaec563435773

It was ignored since then, but recent ruby fails with:
  `ArgumentError: unknown keyword: quirks_mode`
at `JSON.parse` and `JSON.generate` since that commit:
  https://github.com/ruby/ruby/commit/ac60d4ae4dc9aeb522d242406345e7f8834e76cd